### PR TITLE
[feature] 메뉴 생성, 전체 조회 API 구현(#25)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -40,8 +40,14 @@ dependencies {
     runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.5'
     runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.11.5' // JSON 파싱을 위해 필요
 
-    //WebSocket
+    // WebSocket
     implementation 'org.springframework.boot:spring-boot-starter-websocket'
+
+    // Querydsl JPA
+    implementation 'com.querydsl:querydsl-jpa:5.1.0:jakarta'
+    annotationProcessor 'com.querydsl:querydsl-apt:5.1.0:jakarta'
+    annotationProcessor 'jakarta.annotation:jakarta.annotation-api'
+    annotationProcessor 'jakarta.persistence:jakarta.persistence-api'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/example/eat_together/domain/order/controller/OrderController.java
+++ b/src/main/java/com/example/eat_together/domain/order/controller/OrderController.java
@@ -1,12 +1,38 @@
 package com.example.eat_together.domain.order.controller;
 
+import com.example.eat_together.domain.order.dto.OrderResponseDto;
+import com.example.eat_together.domain.order.service.OrderService;
+import com.example.eat_together.global.dto.ApiResponse;
 import lombok.RequiredArgsConstructor;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.data.domain.Page;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
-@RequestMapping
+@RequestMapping("/orders")
 @RequiredArgsConstructor
 public class OrderController {
 
+    private final OrderService orderService;
+
+    // 주문 생성
+    @PostMapping
+    public ResponseEntity<ApiResponse<Void>> createOrder(@AuthenticationPrincipal UserDetails userDetails) {
+
+        orderService.createOrder(Long.valueOf(userDetails.getUsername()));
+        return ResponseEntity.status(HttpStatus.CREATED)
+                .body(ApiResponse.of(null, "주문이 완료되었습니다."));
+    }
+
+    // 주문 목록 조회 (추후 조회기간, 주문상태로 조회 추가 예정)
+    @GetMapping
+    public ResponseEntity<ApiResponse<Page<OrderResponseDto>>> getOrders(@AuthenticationPrincipal UserDetails userDetails,
+                                                                         @RequestParam(value = "page", defaultValue = "1") int page,
+                                                                         @RequestParam(value = "size", defaultValue = "10") int size) {
+        return ResponseEntity.status(HttpStatus.OK)
+                .body(ApiResponse.of(orderService.getOrders(Long.valueOf(userDetails.getUsername()), page, size), "주문 목록을 조회하였습니다."));
+    }
 }

--- a/src/main/java/com/example/eat_together/domain/order/dto/OrderResponseDto.java
+++ b/src/main/java/com/example/eat_together/domain/order/dto/OrderResponseDto.java
@@ -1,0 +1,35 @@
+package com.example.eat_together.domain.order.dto;
+
+import com.example.eat_together.domain.order.entity.Order;
+import com.example.eat_together.domain.order.entity.OrderStatus;
+import com.querydsl.core.annotations.QueryProjection;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+public class OrderResponseDto {
+
+    private final Long id;
+
+    private final Long userId;
+
+    private final OrderStatus status;
+
+    private final double totalPrice;
+
+    private final LocalDateTime createdAt;
+
+    private final LocalDateTime updatedAt;
+
+    @QueryProjection
+    public OrderResponseDto(Order order) {
+        this.id = order.getId();
+        this.userId = order.getUser().getUserId();
+        this.status = order.getStatus();
+        this.totalPrice = order.getTotalPrice();
+        this.createdAt = order.getCreatedAt();
+        this.updatedAt = order.getUpdatedAt();
+    }
+
+}

--- a/src/main/java/com/example/eat_together/domain/order/entity/Order.java
+++ b/src/main/java/com/example/eat_together/domain/order/entity/Order.java
@@ -1,10 +1,14 @@
 package com.example.eat_together.domain.order.entity;
 
+import com.example.eat_together.domain.rider.entity.Rider;
 import com.example.eat_together.domain.user.entity.User;
 import com.example.eat_together.global.entity.BaseTimeEntity;
 import jakarta.persistence.*;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+
+import java.util.ArrayList;
+import java.util.List;
 
 @Entity
 @Getter
@@ -20,10 +24,42 @@ public class Order extends BaseTimeEntity {
     @JoinColumn(name = "user_id", nullable = false)
     private User user;
 
+    @ManyToOne
+    @JoinColumn(name = "rider_id")
+    private Rider rider;
+
+    @OneToMany(mappedBy = "order", cascade = {CascadeType.PERSIST, CascadeType.REMOVE})
+    private List<OrderItem> orderItems = new ArrayList<>();
+
     @Enumerated(EnumType.STRING)
     @Column(nullable = false)
     private OrderStatus status;
 
     @Column(nullable = false)
-    private boolean isDeleted = false;
+    private double totalPrice;
+
+    @Column(nullable = false)
+    private boolean isDeleted;
+
+    public static Order of(User user) {
+        Order order = new Order();
+        order.user = user;
+        order.status = OrderStatus.ORDERED;
+        order.isDeleted = false;
+        return order;
+    }
+
+    public void addOrderItem(OrderItem orderItem) {
+        orderItems.add(orderItem);      // Order 입장에서 자식 추가
+        orderItem.setOrder(this);       // OrderItem 입장에서 부모 참조 설정
+    }
+
+    public void calculateTotalPrice() {
+        int total = 0;
+        for (OrderItem orderItem : orderItems) {
+            total += orderItem.getPrice();
+        }
+        this.totalPrice = total;
+    }
+
 }

--- a/src/main/java/com/example/eat_together/domain/order/entity/OrderItem.java
+++ b/src/main/java/com/example/eat_together/domain/order/entity/OrderItem.java
@@ -1,0 +1,42 @@
+package com.example.eat_together.domain.order.entity;
+
+import com.example.eat_together.domain.menu.entity.Menu;
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor
+@Table(name = "order_items")
+public class OrderItem {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "order_id", nullable = false)
+    private Order order;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "menu_id", nullable = false)
+    private Menu menu;
+
+    private int quantity;
+
+    private int price;
+
+    public static OrderItem of(Order order, Menu menu, int quantity, int price) {
+        OrderItem orderItem = new OrderItem();
+        orderItem.order = order;
+        orderItem.menu = menu;
+        orderItem.quantity = quantity;
+        orderItem.price = price;
+        return orderItem;
+    }
+
+    public void setOrder(Order order) {
+        this.order = order;
+    }
+}

--- a/src/main/java/com/example/eat_together/domain/order/repository/OrderRepository.java
+++ b/src/main/java/com/example/eat_together/domain/order/repository/OrderRepository.java
@@ -5,5 +5,5 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
-public interface OrderRepository extends JpaRepository<Order, Long> {
+public interface OrderRepository extends JpaRepository<Order, Long>, OrderRepositoryCustom {
 }

--- a/src/main/java/com/example/eat_together/domain/order/repository/OrderRepositoryCustom.java
+++ b/src/main/java/com/example/eat_together/domain/order/repository/OrderRepositoryCustom.java
@@ -1,0 +1,11 @@
+package com.example.eat_together.domain.order.repository;
+
+import com.example.eat_together.domain.order.dto.OrderResponseDto;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface OrderRepositoryCustom {
+    Page<OrderResponseDto> findOrders(Pageable pageable);
+}

--- a/src/main/java/com/example/eat_together/domain/order/repository/OrderRepositoryCustomImpl.java
+++ b/src/main/java/com/example/eat_together/domain/order/repository/OrderRepositoryCustomImpl.java
@@ -1,0 +1,39 @@
+package com.example.eat_together.domain.order.repository;
+
+import com.example.eat_together.domain.order.dto.OrderResponseDto;
+import com.example.eat_together.domain.order.dto.QOrderResponseDto;
+import com.querydsl.jpa.impl.JPAQuery;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import jakarta.persistence.EntityManager;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.support.PageableExecutionUtils;
+
+import java.util.List;
+
+import static com.example.eat_together.domain.order.entity.QOrder.order;
+
+public class OrderRepositoryCustomImpl implements OrderRepositoryCustom {
+    private final EntityManager em;
+    private final JPAQueryFactory queryFactory;
+
+    public OrderRepositoryCustomImpl(EntityManager em) {
+        this.em = em;
+        this.queryFactory = new JPAQueryFactory(em);
+    }
+
+    @Override
+    public Page<OrderResponseDto> findOrders(Pageable pageable) {
+        List<OrderResponseDto> content = queryFactory.select(new QOrderResponseDto(order))
+                .from(order)
+                .orderBy(order.createdAt.desc())
+                .offset(pageable.getOffset())
+                .limit(pageable.getPageSize())
+                .fetch();
+
+        JPAQuery<Long> countQuery = queryFactory.select(order.count())
+                .from(order);
+
+        return PageableExecutionUtils.getPage(content, pageable, countQuery::fetchOne);
+    }
+}

--- a/src/main/java/com/example/eat_together/domain/order/service/OrderService.java
+++ b/src/main/java/com/example/eat_together/domain/order/service/OrderService.java
@@ -1,10 +1,52 @@
 package com.example.eat_together.domain.order.service;
 
+import com.example.eat_together.domain.cart.entity.Cart;
+import com.example.eat_together.domain.cart.repository.CartRepository;
+import com.example.eat_together.domain.order.dto.OrderResponseDto;
+import com.example.eat_together.domain.order.repository.OrderRepository;
+import com.example.eat_together.domain.user.repository.UserRepository;
+import com.example.eat_together.global.exception.CustomException;
+import com.example.eat_together.global.exception.ErrorCode;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
 public class OrderService {
+    private final CartRepository cartRepository;
+    private final OrderRepository orderRepository;
+    private final UserRepository userRepository;
 
+    // 주문 생성
+    @Transactional
+    public void createOrder(Long userId) {
+
+        Cart cart = cartRepository.findByUserId(userId)
+                .orElseThrow(() -> new CustomException(ErrorCode.CART_NOT_FOUND));
+
+        // 장바구니 api 확인 후 수정 예정
+//        User user = cart.getUser();
+//
+//        Order order = Order.of(user);
+//
+//        for (CartItem cartItem : cart.getCartItems()) {
+//            OrderItem orderItem = OrderItem.of(order, cartItem.getMenu(), cartItem.getQuantity(), cartItem.getPrice());
+//            order.addOrderItem(orderItem);
+//        }
+
+//        order.calculateTotalPrice();
+//
+//        orderRepository.save(order);
+
+    }
+
+    public Page<OrderResponseDto> getOrders(Long userId, int page, int size) {
+        userRepository.findById(userId).orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
+        Pageable pageable = PageRequest.of(page - 1, size);
+        return orderRepository.findOrders(pageable);
+    }
 }

--- a/src/main/java/com/example/eat_together/global/exception/ErrorCode.java
+++ b/src/main/java/com/example/eat_together/global/exception/ErrorCode.java
@@ -10,7 +10,7 @@ public enum ErrorCode {
     INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "서버 내부 오류입니다."),
 
     // 400 BAD_REQUEST
-    INFO_MISMATCH(HttpStatus.BAD_REQUEST,"아이디 또는 비밀번호가 다릅니다."),
+    INFO_MISMATCH(HttpStatus.BAD_REQUEST, "아이디 또는 비밀번호가 다릅니다."),
     PASSWORD_WRONG(HttpStatus.BAD_REQUEST, "비밀번호가 다릅니다."),
     INVALID_REQUEST(HttpStatus.BAD_REQUEST, "잘못된 요청입니다."),
     UPDATE_CONTENT_REQUIRED(HttpStatus.BAD_REQUEST, "변경 내용을 입력해야 합니다."),
@@ -19,6 +19,7 @@ public enum ErrorCode {
     USER_NOT_FOUND(HttpStatus.NOT_FOUND, "사용자를 찾을 수 없습니다."),
     STORE_NOT_FOUND(HttpStatus.NOT_FOUND, "매장을 찾을 수 없습니다."),
     MENU_NOT_FOUND(HttpStatus.NOT_FOUND, "메뉴를 찾을 수 없습니다."),
+    CART_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 장바구니를 찾을 수 없습니다."),
 
     // 409 CONFLICT
     DUPLICATE_USER(HttpStatus.CONFLICT, "중복된 유저가 있습니다");


### PR DESCRIPTION
## 이슈 번호
#25 

## 작업 내용
- Querydsl JPA 의존성 추가
- Order Entity에 rider, orderItems, totalPrice 필드 및 주문 생성 시 필요한 메서드 추가
- OrderItem Entity 추가
- OrderResponseDto 추가
- ErrorCode에 장바구니 관련 enum 추가
- 메뉴 생성, 전체 조회 API 구현(OrderRepositoryCustom, OrderRepositoryCustomImpl 클래스 추가)

## 스크린샷(선택)
