### PR TITLE
[refactor] : 메뉴 수정 시 요청 필드에 수정 원하는 필드만 작성 가능하도록 변경 (#23)

### DIFF
--- a/src/main/java/com/example/eat_together/domain/menu/controller/MenuController.java
+++ b/src/main/java/com/example/eat_together/domain/menu/controller/MenuController.java
@@ -1,6 +1,7 @@
 package com.example.eat_together.domain.menu.controller;
 
 import com.example.eat_together.domain.menu.dto.request.MenuRequestDto;
+import com.example.eat_together.domain.menu.dto.request.MenuUpdateRequestDto;
 import com.example.eat_together.domain.menu.dto.respones.MenuResponseDto;
 import com.example.eat_together.domain.menu.dto.respones.PagingMenuResponseDto;
 import com.example.eat_together.domain.menu.entity.Menu;
@@ -72,7 +73,7 @@ public class MenuController {
     @PatchMapping("/{menuId}")
     public ResponseEntity<ApiResponse<MenuResponseDto>> updateMenu(@PathVariable Long storeId,
                                                                    @PathVariable Long menuId,
-                                                                   @RequestBody MenuRequestDto request) {
+                                                                   @RequestBody MenuUpdateRequestDto request) {
 
         MenuResponseDto responseDto = menuService.updateMenu(storeId, menuId, request);
 

--- a/src/main/java/com/example/eat_together/domain/menu/dto/request/MenuUpdateRequestDto.java
+++ b/src/main/java/com/example/eat_together/domain/menu/dto/request/MenuUpdateRequestDto.java
@@ -1,0 +1,22 @@
+package com.example.eat_together.domain.menu.dto.request;
+
+import lombok.Getter;
+
+@Getter
+public class MenuUpdateRequestDto {
+
+    private final String imageUrl;
+
+    private final String name;
+
+    private final Double price;
+
+    private final String description;
+
+    public MenuUpdateRequestDto(String imageUrl, String name, double price, String description) {
+        this.imageUrl = imageUrl;
+        this.name = name;
+        this.price = price;
+        this.description = description;
+    }
+}

--- a/src/main/java/com/example/eat_together/domain/menu/entity/Menu.java
+++ b/src/main/java/com/example/eat_together/domain/menu/entity/Menu.java
@@ -56,6 +56,22 @@ public class Menu extends BaseTimeEntity {
         this.price = price;
     }
 
+    public void updateImageUrl(String imageUrl) {
+        this.imageUrl = imageUrl;
+    }
+
+    public void updateName(String name) {
+        this.name = name;
+    }
+
+    public void updateDescription(String description) {
+        this.description = description;
+    }
+
+    public void updatePrice(double price) {
+        this.price = price;
+    }
+
 
     // 메뉴 삭제 시 사용
     public void deleted() {

--- a/src/main/java/com/example/eat_together/domain/menu/service/MenuService.java
+++ b/src/main/java/com/example/eat_together/domain/menu/service/MenuService.java
@@ -1,6 +1,7 @@
 package com.example.eat_together.domain.menu.service;
 
 import com.example.eat_together.domain.menu.dto.request.MenuRequestDto;
+import com.example.eat_together.domain.menu.dto.request.MenuUpdateRequestDto;
 import com.example.eat_together.domain.menu.dto.respones.MenuResponseDto;
 import com.example.eat_together.domain.menu.dto.respones.PagingMenuResponseDto;
 import com.example.eat_together.domain.menu.entity.Menu;
@@ -71,7 +72,7 @@ public class MenuService {
     }
 
     @Transactional
-    public MenuResponseDto updateMenu(Long storeId, Long menuId, MenuRequestDto request) {
+    public MenuResponseDto updateMenu(Long storeId, Long menuId, MenuUpdateRequestDto request) {
 
         Store store = storeRepository.findById(storeId)
                 .orElseThrow(() -> new CustomException(ErrorCode.STORE_NOT_FOUND));
@@ -82,23 +83,33 @@ public class MenuService {
             throw new CustomException(ErrorCode.MENU_NOT_FOUND);
         }
 
-        if (menu.getImageUrl().equals(request.getImageUrl())
-                && menu.getName().equals(request.getName())
-                && menu.getDescription().equals(request.getDescription())
-                && Double.compare(menu.getPrice(), request.getPrice()) == 0) {
+        boolean isUpdated = false;
 
+        if (request.getImageUrl() != null && !request.getImageUrl().equals(menu.getImageUrl())) {
+            menu.updateImageUrl(request.getImageUrl());
+            isUpdated = true;
+        }
+
+        if (request.getName() != null && !request.getName().equals(menu.getName())) {
+            menu.updateName(request.getName());
+            isUpdated = true;
+        }
+
+        if (request.getDescription() != null && !request.getDescription().equals(menu.getDescription())) {
+            menu.updateDescription(request.getDescription());
+            isUpdated = true;
+        }
+
+        if (request.getPrice() != null && !request.getPrice().equals(menu.getPrice())) {
+            menu.updatePrice(request.getPrice());
+            isUpdated = true;
+        }
+
+        if (!isUpdated) {
             throw new CustomException(ErrorCode.UPDATE_CONTENT_REQUIRED);
         }
 
-        menu.update(
-                request.getImageUrl(),
-                request.getName(),
-                request.getDescription(),
-                request.getPrice()
-        );
-
         return MenuResponseDto.from(menu);
-
     }
 
     @Transactional


### PR DESCRIPTION
## 이슈 번호
#23 

## 작업 내용
- 메뉴 수정 시 원하는 필드만 입력해도 작동하도록 변경하였습니다.

기존 : 하나의 속성만 수정하더라도 요청 시 모든 속성을 넣어야했습니다.

변경 후 : 하나의 속성을 수정할 땐 하나의 속성만 요청할 수 있도록 변경했습니다.

## 스크린샷(선택)
