### PR TITLE
feat: CartItem 금액 관련 필드를 double 타입으로 통일

### DIFF
--- a/src/main/java/com/example/eat_together/domain/cart/dto/CartItemResponseDto.java
+++ b/src/main/java/com/example/eat_together/domain/cart/dto/CartItemResponseDto.java
@@ -9,14 +9,14 @@ public class CartItemResponseDto {
     private final Long itemId;
     private final String menuName;
     private final int quantity;
-    private final int price;         // 단일 메뉴 가격
-    private final int totalPrice;    // 수량 * 가격
+    private final double price;          // 단일 메뉴 가격 (소수점 가능)
+    private final double totalPrice;     // 수량 * 가격
 
     public CartItemResponseDto(CartItem cartItem) {
         this.itemId = cartItem.getId();
         this.menuName = cartItem.getMenu().getName();
         this.quantity = cartItem.getQuantity();
-        this.price = (int) cartItem.getMenu().getPrice(); // TODO : 이거 고침
-        this.totalPrice = cartItem.getTotalPrice();
+        this.price = cartItem.getMenu().getPrice(); // double로 바로 저장
+        this.totalPrice = cartItem.getTotalPrice(); // 메뉴 엔티티에서 double로 계산된 totalPrice 반환
     }
 }

--- a/src/main/java/com/example/eat_together/domain/cart/dto/CartResponseDto.java
+++ b/src/main/java/com/example/eat_together/domain/cart/dto/CartResponseDto.java
@@ -8,10 +8,10 @@ import java.util.List;
 public class CartResponseDto {
 
     private final List<CartItemResponseDto> items;
-    private final int totalPrice;
+    private final double totalPrice;
 
     public CartResponseDto(List<CartItemResponseDto> items) {
         this.items = items;
-        this.totalPrice = items.stream().mapToInt(CartItemResponseDto::getTotalPrice).sum();
+        this.totalPrice = items.stream().mapToDouble(CartItemResponseDto::getTotalPrice).sum();
     }
 }

--- a/src/main/java/com/example/eat_together/domain/cart/entity/CartItem.java
+++ b/src/main/java/com/example/eat_together/domain/cart/entity/CartItem.java
@@ -41,7 +41,7 @@ public class CartItem extends BaseTimeEntity {
         this.quantity = quantity;
     }
 
-    public int getTotalPrice() {
-        return (int) (menu.getPrice() * quantity);
+    public double getTotalPrice() {
+        return menu.getPrice() * quantity;
     }
 }


### PR DESCRIPTION
## 이슈 번호
#43 

## 작업 내용
- CartItemResponseDto의 price, totalPrice 필드를 double로 변경
- CartItem 엔티티의 getTotalPrice() 메서드 반환 타입을 double로 명시