### PR TITLE
feat: 주문 상태 변경 및 주문내역 단일 삭제 구현(#50)

### DIFF
--- a/src/main/java/com/example/eat_together/domain/order/controller/OrderController.java
+++ b/src/main/java/com/example/eat_together/domain/order/controller/OrderController.java
@@ -2,6 +2,9 @@ package com.example.eat_together.domain.order.controller;
 
 import com.example.eat_together.domain.order.dto.OrderDetailResponseDto;
 import com.example.eat_together.domain.order.dto.OrderResponseDto;
+import com.example.eat_together.domain.order.dto.OrderStatusUpdateResponseDto;
+import com.example.eat_together.domain.order.orderEnum.OrderResponse;
+import com.example.eat_together.domain.order.orderEnum.OrderStatus;
 import com.example.eat_together.domain.order.service.OrderService;
 import com.example.eat_together.global.dto.ApiResponse;
 import lombok.RequiredArgsConstructor;
@@ -25,7 +28,7 @@ public class OrderController {
 
         orderService.createOrder(Long.valueOf(userDetails.getUsername()));
         return ResponseEntity.status(HttpStatus.CREATED)
-                .body(ApiResponse.of(null, "주문이 완료되었습니다."));
+                .body(ApiResponse.of(null, OrderResponse.ORDER_CREATED.getMessage()));
     }
 
     // 주문 목록 페이징 조회 (추후 조회기간, 주문상태로 조회 추가 예정)
@@ -34,13 +37,29 @@ public class OrderController {
                                                                          @RequestParam(value = "page", defaultValue = "1") int page,
                                                                          @RequestParam(value = "size", defaultValue = "10") int size) {
         return ResponseEntity.status(HttpStatus.OK)
-                .body(ApiResponse.of(orderService.getOrders(Long.valueOf(userDetails.getUsername()), page, size), "주문 목록을 조회하였습니다."));
+                .body(ApiResponse.of(orderService.getOrders(Long.valueOf(userDetails.getUsername()), page, size), OrderResponse.ORDER_LIST_FOUND.getMessage()));
     }
 
     // 주문 목록 단일 조회
     @GetMapping("/{orderId}")
     public ResponseEntity<ApiResponse<OrderDetailResponseDto>> getOrder(@AuthenticationPrincipal UserDetails userDetails, @PathVariable Long orderId) {
         return ResponseEntity.status(HttpStatus.OK)
-                .body(ApiResponse.of(orderService.getOrder(Long.valueOf(userDetails.getUsername()), orderId), "주문 목록을 조회하였습니다."));
+                .body(ApiResponse.of(orderService.getOrder(Long.valueOf(userDetails.getUsername()), orderId), OrderResponse.ORDER_FOUND.getMessage()));
     }
+
+    // 주문 상태 변경(가게 권한)
+    @PatchMapping("/{orderId}/status")
+    public ResponseEntity<ApiResponse<OrderStatusUpdateResponseDto>> updateOrderStatus(@AuthenticationPrincipal UserDetails userDetails, @PathVariable Long orderId, @RequestBody OrderStatus status) {
+        return ResponseEntity.status(HttpStatus.OK)
+                .body(ApiResponse.of(orderService.updateOrderStatus(Long.valueOf(userDetails.getUsername()), orderId, status), OrderResponse.ORDER_UPDATED.getMessage()));
+    }
+
+    // 주문 단건 삭제 (소프트 딜리트)
+    @DeleteMapping("/{orderId}")
+    public ResponseEntity<ApiResponse<Void>> deleteOrder(@AuthenticationPrincipal UserDetails userDetails, @PathVariable Long orderId) {
+        orderService.deleteOrder(Long.valueOf(userDetails.getUsername()), orderId);
+        return ResponseEntity.status(HttpStatus.OK)
+                .body(ApiResponse.of(null, OrderResponse.ORDER_DELETED.getMessage()));
+    }
+
 }

--- a/src/main/java/com/example/eat_together/domain/order/dto/OrderDetailResponseDto.java
+++ b/src/main/java/com/example/eat_together/domain/order/dto/OrderDetailResponseDto.java
@@ -1,7 +1,7 @@
 package com.example.eat_together.domain.order.dto;
 
 import com.example.eat_together.domain.order.entity.Order;
-import com.example.eat_together.domain.order.entity.OrderStatus;
+import com.example.eat_together.domain.order.orderEnum.OrderStatus;
 import lombok.Getter;
 
 import java.time.LocalDateTime;

--- a/src/main/java/com/example/eat_together/domain/order/dto/OrderResponseDto.java
+++ b/src/main/java/com/example/eat_together/domain/order/dto/OrderResponseDto.java
@@ -1,7 +1,7 @@
 package com.example.eat_together.domain.order.dto;
 
 import com.example.eat_together.domain.order.entity.Order;
-import com.example.eat_together.domain.order.entity.OrderStatus;
+import com.example.eat_together.domain.order.orderEnum.OrderStatus;
 import com.querydsl.core.annotations.QueryProjection;
 import lombok.Getter;
 

--- a/src/main/java/com/example/eat_together/domain/order/dto/OrderStatusUpdateResponseDto.java
+++ b/src/main/java/com/example/eat_together/domain/order/dto/OrderStatusUpdateResponseDto.java
@@ -1,0 +1,32 @@
+package com.example.eat_together.domain.order.dto;
+
+import com.example.eat_together.domain.order.entity.Order;
+import com.example.eat_together.domain.order.orderEnum.OrderStatus;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+public class OrderStatusUpdateResponseDto {
+
+    private final Long id;
+
+    private final Long userId;
+
+    private final Long storeId;
+
+    private final OrderStatus status;
+
+    private final LocalDateTime createdAt;
+
+    private final LocalDateTime updatedAt;
+
+    public OrderStatusUpdateResponseDto(Order order) {
+        this.id = order.getId();
+        this.userId = order.getUser().getUserId();
+        this.storeId = order.getStore().getStoreId();
+        this.status = order.getStatus();
+        this.createdAt = order.getCreatedAt();
+        this.updatedAt = order.getUpdatedAt();
+    }
+}

--- a/src/main/java/com/example/eat_together/domain/order/entity/Order.java
+++ b/src/main/java/com/example/eat_together/domain/order/entity/Order.java
@@ -1,5 +1,6 @@
 package com.example.eat_together.domain.order.entity;
 
+import com.example.eat_together.domain.order.orderEnum.OrderStatus;
 import com.example.eat_together.domain.rider.entity.Rider;
 import com.example.eat_together.domain.store.entity.Store;
 import com.example.eat_together.domain.user.entity.User;
@@ -24,7 +25,6 @@ public class Order extends BaseTimeEntity {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "user_id", nullable = false)
     private User user;
-
     @ManyToOne
     @JoinColumn(name = "store_id")
     private Store store;
@@ -66,6 +66,14 @@ public class Order extends BaseTimeEntity {
         }
         total += store.getDeliveryFee();
         this.totalPrice = total;
+    }
+
+    public void updateStatus(OrderStatus status) {
+        this.status = status;
+    }
+
+    public void deletedOrder() {
+        this.isDeleted = true;
     }
 
 }

--- a/src/main/java/com/example/eat_together/domain/order/orderEnum/OrderResponse.java
+++ b/src/main/java/com/example/eat_together/domain/order/orderEnum/OrderResponse.java
@@ -1,0 +1,16 @@
+package com.example.eat_together.domain.order.orderEnum;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum OrderResponse {
+    ORDER_CREATED("주문이 완료되었습니다."),
+    ORDER_LIST_FOUND("주문 목록을 조회하였습니다."),
+    ORDER_FOUND("주문을 조회하였습니다."),
+    ORDER_UPDATED("주문 상태를 변경하였습니다."),
+    ORDER_DELETED("주문정보가 삭제되었습니다.");
+
+    private final String message;
+}

--- a/src/main/java/com/example/eat_together/domain/order/orderEnum/OrderStatus.java
+++ b/src/main/java/com/example/eat_together/domain/order/orderEnum/OrderStatus.java
@@ -1,4 +1,4 @@
-package com.example.eat_together.domain.order.entity;
+package com.example.eat_together.domain.order.orderEnum;
 
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -10,5 +10,5 @@ public enum OrderStatus {
     DELIVERING("배달중"),
     DELIVERED("배달완료");
 
-    private final String status;
+    private final String message;
 }

--- a/src/main/java/com/example/eat_together/global/exception/ErrorCode.java
+++ b/src/main/java/com/example/eat_together/global/exception/ErrorCode.java
@@ -14,10 +14,11 @@ public enum ErrorCode {
     PASSWORD_WRONG(HttpStatus.BAD_REQUEST, "비밀번호가 다릅니다."),
     INVALID_REQUEST(HttpStatus.BAD_REQUEST, "잘못된 요청입니다."),
     UPDATE_CONTENT_REQUIRED(HttpStatus.BAD_REQUEST, "변경 내용을 입력해야 합니다."),
-    DELETED_USER(HttpStatus.BAD_REQUEST,"삭제된 유저입니다"),
+    DELETED_USER(HttpStatus.BAD_REQUEST, "삭제된 유저입니다"),
 
     // 403 FORBIDEN
     ADMIN_ACCOUNT_CANNOT_BE_DELETED(HttpStatus.FORBIDDEN, "관리자 계정은 삭제할 수 없습니다."),
+    FORBIDDEN_ACCESS(HttpStatus.FORBIDDEN, "접근 권한이 없습니다"),
 
     // 404 NOT_FOUND
     USER_NOT_FOUND(HttpStatus.NOT_FOUND, "사용자를 찾을 수 없습니다."),


### PR DESCRIPTION
## 이슈 번호
 #50 
## 작업 내용
- 주문 상태 변경 ResponseDto 추가
- OrderResponse enum 클래스 추가
- 주문 상태 변경 및 주문내역 단일 삭제 구현
- 추후 소프트 딜리트된 주문 내역은 조회할 수 없도록 구현할 예정입니다.
## 스크린샷(선택)
