### PR TITLE
fix: 주문 생성 시 store 누락으로 인한 NPE 해결(#61)

### DIFF
--- a/src/main/java/com/example/eat_together/domain/order/entity/Order.java
+++ b/src/main/java/com/example/eat_together/domain/order/entity/Order.java
@@ -46,9 +46,10 @@ public class Order extends BaseTimeEntity {
     @Column(nullable = false)
     private boolean isDeleted;
 
-    public static Order of(User user) {
+    public static Order of(User user, Store store) {
         Order order = new Order();
         order.user = user;
+        order.store = store;
         order.status = OrderStatus.ORDERED;
         order.isDeleted = false;
         return order;

--- a/src/main/java/com/example/eat_together/domain/order/service/OrderService.java
+++ b/src/main/java/com/example/eat_together/domain/order/service/OrderService.java
@@ -10,6 +10,7 @@ import com.example.eat_together.domain.order.entity.Order;
 import com.example.eat_together.domain.order.entity.OrderItem;
 import com.example.eat_together.domain.order.orderEnum.OrderStatus;
 import com.example.eat_together.domain.order.repository.OrderRepository;
+import com.example.eat_together.domain.store.entity.Store;
 import com.example.eat_together.domain.user.entity.User;
 import com.example.eat_together.domain.user.entity.UserRole;
 import com.example.eat_together.domain.user.repository.UserRepository;
@@ -40,7 +41,13 @@ public class OrderService {
 
         User user = cart.getUser();
 
-        Order order = Order.of(user);
+        if (cart.getCartItems().isEmpty()) {
+            throw new CustomException(ErrorCode.CART_ITEM_NOT_FOUND);
+        }
+
+        Store store = cart.getCartItems().get(0).getMenu().getStore();
+
+        Order order = Order.of(user, store);
 
         for (CartItem cartItem : cart.getCartItems()) {
             OrderItem orderItem = OrderItem.of(order, cartItem.getMenu(), cartItem.getQuantity());


### PR DESCRIPTION
## 이슈 번호
#61 
## 작업 내용
- Order of에 order.store = store; 추가
- 주문 생성 시 CartItem이 비어있는지 확인하고, 메뉴에서 Store 정보를 가져올 수 있도록 로직 개선
## 스크린샷(선택)
