### PR TITLE
[feature] Menu 도메인 예외처리 추가 (#70)

### DIFF
--- a/src/main/java/com/example/eat_together/domain/menu/controller/MenuController.java
+++ b/src/main/java/com/example/eat_together/domain/menu/controller/MenuController.java
@@ -13,6 +13,8 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.web.PageableDefault;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
@@ -27,9 +29,10 @@ public class MenuController {
 
     @PostMapping
     public ResponseEntity<ApiResponse> createMenu(@PathVariable Long storeId,
-                                                  @Valid @RequestBody MenuRequestDto requestDto) {
+                                                  @Valid @RequestBody MenuRequestDto requestDto,
+                                                  @AuthenticationPrincipal UserDetails userDetails) {
 
-        menuService.createMenu(storeId, requestDto);
+        menuService.createMenu(storeId, requestDto, userDetails);
 
         ApiResponse<Menu> response = new ApiResponse<>
                 (
@@ -73,9 +76,10 @@ public class MenuController {
     @PatchMapping("/{menuId}")
     public ResponseEntity<ApiResponse<MenuResponseDto>> updateMenu(@PathVariable Long storeId,
                                                                    @PathVariable Long menuId,
-                                                                   @RequestBody MenuUpdateRequestDto request) {
+                                                                   @RequestBody MenuUpdateRequestDto request,
+                                                                   @AuthenticationPrincipal UserDetails userDetails) {
 
-        MenuResponseDto responseDto = menuService.updateMenu(storeId, menuId, request);
+        MenuResponseDto responseDto = menuService.updateMenu(storeId, menuId, request, userDetails);
 
         ApiResponse<MenuResponseDto> response = new ApiResponse<>
                 (
@@ -88,9 +92,10 @@ public class MenuController {
 
     @DeleteMapping("/{menuId}")
     public ResponseEntity<ApiResponse> deletedMenu(@PathVariable Long storeId,
-                                                   @PathVariable Long menuId) {
+                                                   @PathVariable Long menuId,
+                                                   @AuthenticationPrincipal UserDetails userDetails) {
 
-        menuService.deleteMenu(storeId, menuId);
+        menuService.deleteMenu(storeId, menuId, userDetails);
 
         ApiResponse<Menu> response = new ApiResponse<>
                 (

--- a/src/main/java/com/example/eat_together/domain/menu/dto/request/MenuRequestDto.java
+++ b/src/main/java/com/example/eat_together/domain/menu/dto/request/MenuRequestDto.java
@@ -1,7 +1,9 @@
 package com.example.eat_together.domain.menu.dto.request;
 
+import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
 import lombok.Getter;
 
 @Getter
@@ -11,12 +13,15 @@ public class MenuRequestDto {
     private final String imageUrl;
 
     @NotBlank(message = "메뉴 이름이 없습니다.")
+    @Size(max = 50, message = "메뉴 이름은 50자 이하여야 합니다.")
     private final String name;
 
     @NotNull(message = "가격이 없습니다.")
+    @Min(value = 0, message = "가격에 음수를 입력할 수 없습니다.")
     private final double price;
 
     @NotBlank(message = "메뉴 설명이 없습니다.")
+    @Size(max = 255, message = "메뉴 설명은 255자 이하여야 합니다.")
     private final String description;
 
     public MenuRequestDto(String imageUrl, String name, double price, String description) {

--- a/src/main/java/com/example/eat_together/domain/menu/repository/MenuRepository.java
+++ b/src/main/java/com/example/eat_together/domain/menu/repository/MenuRepository.java
@@ -10,8 +10,10 @@ import org.springframework.stereotype.Repository;
 @Repository
 public interface MenuRepository extends JpaRepository<Menu, Long> {
 
-    Page<Menu> findAllByStore(Store store, Pageable pageable);
+    Page<Menu> findAllByStoreAndIsDeletedFalse(Store store, Pageable pageable);
 
     Menu findByMenuIdAndStore(Long menuId, Store store);
+
+    boolean existsByStoreAndNameAndIsDeletedFalse(Store store, String name);
 
 }

--- a/src/main/java/com/example/eat_together/global/exception/ErrorCode.java
+++ b/src/main/java/com/example/eat_together/global/exception/ErrorCode.java
@@ -38,7 +38,7 @@ public enum ErrorCode {
     STORE_ALREADY_OPEN(HttpStatus.CONFLICT, "이미 영업 중인 매장입니다."),
     STORE_ALREADY_CLOSED(HttpStatus.CONFLICT, "이미 영업 종료된 매장입니다."),
     STORE_NAME_DUPLICATED(HttpStatus.CONFLICT, "동일한 이름의 매장을 등록할 수 없습니다."),
-    ;
+    MENU_NAME_DUPLICATED(HttpStatus.CONFLICT, "매장에 동일한 이름의 메뉴를 등록할 수 없습니다.");
 
 
     private final HttpStatus status;


### PR DESCRIPTION
## 이슈 번호
#70 

## 작업 내용
- 매장 소유자만 메뉴 생성, 수정, 삭제 할 수 있도록 예외처리

- 삭제 처리된 매장 조회 시도 시 예외처리

- 같은 매장에 동일한 이름의 메뉴를 등록할 수 없도록 예외처리

## 스크린샷(선택)
