### PR TITLE
feat: 주문 목록 조회, 상태 변경 시 예외처리 추가(#72)

### DIFF
--- a/src/main/java/com/example/eat_together/global/exception/ErrorCode.java
+++ b/src/main/java/com/example/eat_together/global/exception/ErrorCode.java
@@ -17,6 +17,8 @@ public enum ErrorCode {
     DELETED_USER(HttpStatus.BAD_REQUEST, "삭제된 유저입니다"),
     STORE_ACCESS_DENIED(HttpStatus.BAD_REQUEST, "자신의 매장이 아닙니다."),
     STORE_INVALID_TIME(HttpStatus.BAD_REQUEST, "오픈 시간이 종료 시간보다 빨라야 합니다."),
+    ORDER_INVALID_PERIOD(HttpStatus.BAD_REQUEST, "조회 시작일은 종료일보다 이전이어야 합니다."),
+    ORDER_PERIOD_MISMATCH(HttpStatus.BAD_REQUEST, "조회 시작일과 종료일은 함께 입력되어야 합니다."),
 
     // 403 FORBIDEN
     ADMIN_ACCOUNT_CANNOT_BE_DELETED(HttpStatus.FORBIDDEN, "관리자 계정은 삭제할 수 없습니다."),


### PR DESCRIPTION
## 이슈 번호
#72 
## 작업 내용
- 조회 시작일과 종료일 중에 하나만 입력했을 경우 예외 발생
- 조회 시작일이 종료일보다 늦은 경우 예외 발생
- 가게 오너 Id와 요청한 사용자 Id가 다를 경우 예외 발생

## 스크린샷(선택)
