### PR TITLE
feat: 주문 생성 시 JPA 비관적 락 적용(#81)

### DIFF
--- a/src/main/java/com/example/eat_together/domain/order/repository/OrderRepositoryCustom.java
+++ b/src/main/java/com/example/eat_together/domain/order/repository/OrderRepositoryCustom.java
@@ -8,6 +8,7 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Repository;
 
 import java.time.LocalDate;
+import java.util.List;
 import java.util.Optional;
 
 @Repository
@@ -15,4 +16,6 @@ public interface OrderRepositoryCustom {
     Page<OrderResponseDto> findOrdersByUserId(Long userId, Pageable pageable, LocalDate startDate, LocalDate endDate, OrderStatus status);
 
     Optional<Order> findByIdAndUserId(Long orderId, Long userId);
+
+    List<Order> findByUserIdAndStoreIdAndStatus(Long userId, Long storeId, OrderStatus status);
 }

--- a/src/main/java/com/example/eat_together/domain/order/repository/OrderRepositoryCustomImpl.java
+++ b/src/main/java/com/example/eat_together/domain/order/repository/OrderRepositoryCustomImpl.java
@@ -8,6 +8,7 @@ import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.jpa.impl.JPAQuery;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import jakarta.persistence.EntityManager;
+import jakarta.persistence.LockModeType;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.support.PageableExecutionUtils;
@@ -73,4 +74,13 @@ public class OrderRepositoryCustomImpl implements OrderRepositoryCustom {
                 .fetchOne());
     }
 
+    @Override
+    public List<Order> findByUserIdAndStoreIdAndStatus(Long userId, Long storeId, OrderStatus status) {
+        return queryFactory.selectFrom(order)
+                .where(order.user.userId.eq(userId),
+                        order.store.storeId.eq(storeId),
+                        order.status.eq(status))
+                .setLockMode(LockModeType.PESSIMISTIC_WRITE)  // JPA 비관적 락 설정
+                .fetch();
+    }
 }

--- a/src/main/java/com/example/eat_together/domain/order/service/OrderService.java
+++ b/src/main/java/com/example/eat_together/domain/order/service/OrderService.java
@@ -24,6 +24,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDate;
+import java.util.List;
 
 @Service
 @RequiredArgsConstructor
@@ -46,6 +47,13 @@ public class OrderService {
         }
 
         Store store = cart.getCartItems().get(0).getMenu().getStore();
+
+        // 주문완료상태인 주문이 같은 가게에 있으면 중복 주문으로 간주 (JPA 비관적락 적용)
+        List<Order> orderWithOrdered =
+                orderRepository.findByUserIdAndStoreIdAndStatus(userId, store.getStoreId(), OrderStatus.ORDERED);
+        if (!orderWithOrdered.isEmpty()) {
+            throw new CustomException(ErrorCode.DUPLICATE_ORDER);
+        }
 
         Order order = Order.of(user, store);
 

--- a/src/main/java/com/example/eat_together/global/exception/ErrorCode.java
+++ b/src/main/java/com/example/eat_together/global/exception/ErrorCode.java
@@ -40,7 +40,8 @@ public enum ErrorCode {
     STORE_ALREADY_OPEN(HttpStatus.CONFLICT, "이미 영업 중인 매장입니다."),
     STORE_ALREADY_CLOSED(HttpStatus.CONFLICT, "이미 영업 종료된 매장입니다."),
     STORE_NAME_DUPLICATED(HttpStatus.CONFLICT, "동일한 이름의 매장을 등록할 수 없습니다."),
-    MENU_NAME_DUPLICATED(HttpStatus.CONFLICT, "매장에 동일한 이름의 메뉴를 등록할 수 없습니다.");
+    MENU_NAME_DUPLICATED(HttpStatus.CONFLICT, "매장에 동일한 이름의 메뉴를 등록할 수 없습니다."),
+    DUPLICATE_ORDER(HttpStatus.CONFLICT, "이미 처리 중인 주문이 있습니다.");
 
 
     private final HttpStatus status;


### PR DESCRIPTION
## 이슈 번호
#81 
## 작업 내용
- 주문 생성 시 JPA 비관적 락 적용
## 스크린샷(선택)
