### PR TITLE
feat: 주문 단일 조회 Redis 캐싱 적용, 주문 페이징 조회 시 메뉴명/가게명으로 검색 기능 추가 및 N+1문제 해결(#135, #137)

### DIFF
--- a/src/main/java/com/example/eat_together/domain/order/controller/OrderController.java
+++ b/src/main/java/com/example/eat_together/domain/order/controller/OrderController.java
@@ -40,11 +40,13 @@ public class OrderController {
     public ResponseEntity<ApiResponse<Page<OrderResponseDto>>> getOrders(@AuthenticationPrincipal UserDetails userDetails,
                                                                          @RequestParam(value = "page", defaultValue = "1") int page,
                                                                          @RequestParam(value = "size", defaultValue = "10") int size,
+                                                                         @RequestParam(required = false) String menuName,
+                                                                         @RequestParam(required = false) String storeName,
                                                                          @RequestParam(required = false) LocalDate startDate,
                                                                          @RequestParam(required = false) LocalDate endDate,
                                                                          @RequestParam(required = false) OrderStatus status) {
         return ResponseEntity.status(HttpStatus.OK)
-                .body(ApiResponse.of(orderService.getOrders(Long.valueOf(userDetails.getUsername()), page, size, startDate, endDate, status), OrderResponse.ORDER_LIST_FOUND.getMessage()));
+                .body(ApiResponse.of(orderService.getOrders(Long.valueOf(userDetails.getUsername()), page, size, menuName, storeName, startDate, endDate, status), OrderResponse.ORDER_LIST_FOUND.getMessage()));
     }
 
     // 주문 목록 단일 조회

--- a/src/main/java/com/example/eat_together/domain/order/dto/response/OrderDetailResponseDto.java
+++ b/src/main/java/com/example/eat_together/domain/order/dto/response/OrderDetailResponseDto.java
@@ -19,6 +19,8 @@ public class OrderDetailResponseDto {
 
     private final Long storeId;
 
+    private final String storeName;
+
     private final OrderStatus status;
 
     private final double deliveryFee;
@@ -35,6 +37,7 @@ public class OrderDetailResponseDto {
         this.id = order.getId();
         this.userId = order.getUser().getUserId();
         this.storeId = order.getStore().getStoreId();
+        this.storeName = order.getStore().getName();
         this.status = order.getStatus();
         this.deliveryFee = order.getStore().getDeliveryFee();
         this.totalPrice = order.getTotalPrice();

--- a/src/main/java/com/example/eat_together/domain/order/dto/response/OrderDetailResponseDto.java
+++ b/src/main/java/com/example/eat_together/domain/order/dto/response/OrderDetailResponseDto.java
@@ -2,12 +2,16 @@ package com.example.eat_together.domain.order.dto.response;
 
 import com.example.eat_together.domain.order.entity.Order;
 import com.example.eat_together.domain.order.orderEnum.OrderStatus;
+import lombok.AllArgsConstructor;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 import java.time.LocalDateTime;
 import java.util.List;
 
 @Getter
+@AllArgsConstructor
+@NoArgsConstructor(force = true)
 public class OrderDetailResponseDto {
     private final Long id;
 

--- a/src/main/java/com/example/eat_together/domain/order/dto/response/OrderItemResponseDto.java
+++ b/src/main/java/com/example/eat_together/domain/order/dto/response/OrderItemResponseDto.java
@@ -2,13 +2,15 @@ package com.example.eat_together.domain.order.dto.response;
 
 import lombok.AllArgsConstructor;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Getter
 @AllArgsConstructor
+@NoArgsConstructor(force = true)
 public class OrderItemResponseDto {
-    private Long menuId;
-    private String menuName;
-    private int quantity;
-    private double price;
-    private double totalPrice;
+    private final Long menuId;
+    private final String menuName;
+    private final int quantity;
+    private final double price;
+    private final double totalPrice;
 }

--- a/src/main/java/com/example/eat_together/domain/order/dto/response/OrderResponseDto.java
+++ b/src/main/java/com/example/eat_together/domain/order/dto/response/OrderResponseDto.java
@@ -14,7 +14,7 @@ public class OrderResponseDto {
 
     private final Long userId;
 
-    private final Long storeId;
+    private final String storeName;
 
     private final OrderStatus status;
 
@@ -30,7 +30,7 @@ public class OrderResponseDto {
     public OrderResponseDto(Order order) {
         this.id = order.getId();
         this.userId = order.getUser().getUserId();
-        this.storeId = order.getStore().getStoreId();
+        this.storeName = order.getStore().getName();
         this.status = order.getStatus();
         this.deliveryFee = order.getStore().getDeliveryFee();
         this.totalPrice = order.getTotalPrice();

--- a/src/main/java/com/example/eat_together/domain/order/repository/OrderCacheRepository.java
+++ b/src/main/java/com/example/eat_together/domain/order/repository/OrderCacheRepository.java
@@ -1,0 +1,36 @@
+package com.example.eat_together.domain.order.repository;
+
+import com.example.eat_together.domain.order.dto.response.OrderDetailResponseDto;
+import com.example.eat_together.domain.order.orderEnum.OrderStatus;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Repository;
+
+import java.util.concurrent.TimeUnit;
+
+@Repository
+@RequiredArgsConstructor
+public class OrderCacheRepository {
+
+    private final RedisTemplate<String, OrderDetailResponseDto> orderRedisTemplate;
+
+    private static final String ORDER_CACHE_KEY = "order:"; // 주문 단일 조회 키
+
+    public OrderDetailResponseDto getOrder(Long userId, Long orderId) {
+        return orderRedisTemplate.opsForValue().get(ORDER_CACHE_KEY + userId + ":" + orderId);
+    }
+
+    public void saveOrderCache(Long userId, Long orderId, OrderDetailResponseDto orderDto) {
+        long TTL;
+        if (orderDto.getStatus().equals(OrderStatus.ORDERED) || orderDto.getStatus().equals(OrderStatus.DELIVERING)) {
+            TTL = 5;
+        } else {
+            TTL = 30;
+        }
+        orderRedisTemplate.opsForValue().set(ORDER_CACHE_KEY + userId + ":" + orderId, orderDto, TTL, TimeUnit.MINUTES);
+    }
+
+    public void evictOrder(Long userId, Long orderId) {
+        orderRedisTemplate.delete(ORDER_CACHE_KEY + userId + ":" + orderId);
+    }
+}

--- a/src/main/java/com/example/eat_together/domain/order/repository/OrderRepositoryCustom.java
+++ b/src/main/java/com/example/eat_together/domain/order/repository/OrderRepositoryCustom.java
@@ -13,7 +13,7 @@ import java.util.Optional;
 
 @Repository
 public interface OrderRepositoryCustom {
-    Page<OrderResponseDto> findOrdersByUserId(Long userId, Pageable pageable, LocalDate startDate, LocalDate endDate, OrderStatus status);
+    Page<OrderResponseDto> findOrdersByUserId(Long userId, Pageable pageable, String menuName, String storeName, LocalDate startDate, LocalDate endDate, OrderStatus status);
 
     Optional<Order> findByIdAndUserId(Long orderId, Long userId);
 

--- a/src/main/java/com/example/eat_together/domain/order/service/OrderService.java
+++ b/src/main/java/com/example/eat_together/domain/order/service/OrderService.java
@@ -72,7 +72,7 @@ public class OrderService {
 
     // 주문 목록 조회
     @Transactional(readOnly = true)
-    public Page<OrderResponseDto> getOrders(Long userId, int page, int size, LocalDate startDate, LocalDate endDate, OrderStatus status) {
+    public Page<OrderResponseDto> getOrders(Long userId, int page, int size, String menuName, String storeName, LocalDate startDate, LocalDate endDate, OrderStatus status) {
         Pageable pageable = PageRequest.of(page - 1, size);
 
         // 조회 시작일과 종료일 중에 하나만 입력했을 경우 예외 발생
@@ -84,7 +84,7 @@ public class OrderService {
         if (startDate != null && endDate != null && startDate.isAfter(endDate)) {
             throw new CustomException(ErrorCode.ORDER_INVALID_PERIOD);
         }
-        return orderRepository.findOrdersByUserId(userId, pageable, startDate, endDate, status);
+        return orderRepository.findOrdersByUserId(userId, pageable, menuName, storeName, startDate, endDate, status);
     }
 
     // 주문 목록 단일 조회

--- a/src/main/java/com/example/eat_together/global/config/CacheConfig.java
+++ b/src/main/java/com/example/eat_together/global/config/CacheConfig.java
@@ -2,6 +2,7 @@ package com.example.eat_together.global.config;
 
 import com.example.eat_together.domain.menu.dto.respones.MenuResponseDto;
 import com.example.eat_together.domain.menu.dto.respones.PagingMenuResponseDto;
+import com.example.eat_together.domain.order.dto.response.OrderDetailResponseDto;
 import com.example.eat_together.domain.store.dto.response.PagingStoreResponseDto;
 import com.example.eat_together.domain.store.dto.response.StoreResponseDto;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -82,6 +83,22 @@ public class CacheConfig {
 
         Jackson2JsonRedisSerializer<PagingStoreResponseDto> serializer =
                 new Jackson2JsonRedisSerializer<>(PagingStoreResponseDto.class);
+
+        serializer.setObjectMapper(objectMapper());
+        template.setValueSerializer(serializer);
+        template.afterPropertiesSet();
+        return template;
+    }
+
+    // 주문 단건 조회 Redis 설정
+    @Bean
+    public RedisTemplate<String, OrderDetailResponseDto> orderDetailResponseDtoRedisTemplate(RedisConnectionFactory connectionFactory) {
+        RedisTemplate<String, OrderDetailResponseDto> template = new RedisTemplate<>();
+        template.setConnectionFactory(connectionFactory);
+        template.setKeySerializer(new StringRedisSerializer());
+
+        Jackson2JsonRedisSerializer<OrderDetailResponseDto> serializer =
+                new Jackson2JsonRedisSerializer<>(OrderDetailResponseDto.class);
 
         serializer.setObjectMapper(objectMapper());
         template.setValueSerializer(serializer);

--- a/src/test/java/com/example/eat_together/domain/order/service/OrderServiceTest.java
+++ b/src/test/java/com/example/eat_together/domain/order/service/OrderServiceTest.java
@@ -154,10 +154,10 @@ class OrderServiceTest {
         List<OrderResponseDto> orderDtoList = List.of(dto1, dto2);
         Page<OrderResponseDto> page = new PageImpl<>(orderDtoList);
 
-        given(orderRepository.findOrdersByUserId(eq(user.getUserId()), any(Pageable.class), any(), any(), any())).willReturn(page);
+        given(orderRepository.findOrdersByUserId(eq(user.getUserId()), any(Pageable.class), any(), any(), any(), any(), any())).willReturn(page);
 
         // when
-        Page<OrderResponseDto> response = orderService.getOrders(user.getUserId(), 1, 10, startDate, endDate, OrderStatus.ORDERED);
+        Page<OrderResponseDto> response = orderService.getOrders(user.getUserId(), 1, 10, null, null, startDate, endDate, OrderStatus.ORDERED);
 
         // then
         assertNotNull(response);
@@ -181,10 +181,10 @@ class OrderServiceTest {
         List<OrderResponseDto> orderDtoList = List.of(dto1, dto2);
         Page<OrderResponseDto> page = new PageImpl<>(orderDtoList);
 
-        given(orderRepository.findOrdersByUserId(eq(user.getUserId()), any(Pageable.class), any(), any(), any())).willReturn(page);
+        given(orderRepository.findOrdersByUserId(eq(user.getUserId()), any(Pageable.class), any(), any(), any(), any(), any())).willReturn(page);
 
         // when
-        Page<OrderResponseDto> response = orderService.getOrders(user.getUserId(), 1, 10, null, null, OrderStatus.ORDERED);
+        Page<OrderResponseDto> response = orderService.getOrders(user.getUserId(), 1, 10, null, null, null, null, OrderStatus.ORDERED);
 
         // then
         assertNotNull(response);
@@ -201,7 +201,7 @@ class OrderServiceTest {
         LocalDate endDate1 = null;
 
         // when & then
-        CustomException exception1 = assertThrows(CustomException.class, () -> orderService.getOrders(user.getUserId(), 1, 10, startDate1, endDate1, OrderStatus.ORDERED));
+        CustomException exception1 = assertThrows(CustomException.class, () -> orderService.getOrders(user.getUserId(), 1, 10, null, null, startDate1, endDate1, OrderStatus.ORDERED));
         assertEquals(ErrorCode.ORDER_PERIOD_MISMATCH.getMessage(), exception1.getMessage());
 
         // given
@@ -209,7 +209,7 @@ class OrderServiceTest {
         LocalDate endDate2 = LocalDate.of(2025, 7, 31);
 
         // when & then
-        CustomException exception2 = assertThrows(CustomException.class, () -> orderService.getOrders(user.getUserId(), 1, 10, startDate2, endDate2, OrderStatus.ORDERED));
+        CustomException exception2 = assertThrows(CustomException.class, () -> orderService.getOrders(user.getUserId(), 1, 10, null, null, startDate2, endDate2, OrderStatus.ORDERED));
         assertEquals(ErrorCode.ORDER_PERIOD_MISMATCH.getMessage(), exception2.getMessage());
     }
 
@@ -221,7 +221,7 @@ class OrderServiceTest {
         LocalDate endDate1 = LocalDate.of(2025, 6, 1);
 
         // when & then
-        CustomException exception1 = assertThrows(CustomException.class, () -> orderService.getOrders(user.getUserId(), 1, 10, startDate1, endDate1, OrderStatus.ORDERED));
+        CustomException exception1 = assertThrows(CustomException.class, () -> orderService.getOrders(user.getUserId(), 1, 10, null, null, startDate1, endDate1, OrderStatus.ORDERED));
         assertEquals(ErrorCode.ORDER_INVALID_PERIOD.getMessage(), exception1.getMessage());
     }
 


### PR DESCRIPTION
## 이슈 번호
#135, #137
## 작업 내용
- 주문 단일 조회 Redis 캐싱 적용
- 주문 페이징 조회 시 메뉴명, 가게명으로 검색 기능 추가
- 주문 페이징 조회, 단일 조회 시 N+1 문제 해결
## 스크린샷(선택)
