### PR TITLE
feat: 공유 장바구니 주문 API 추가(#168)

### DIFF
--- a/src/main/java/com/example/eat_together/domain/order/controller/OrderController.java
+++ b/src/main/java/com/example/eat_together/domain/order/controller/OrderController.java
@@ -26,7 +26,7 @@ public class OrderController {
 
     private final OrderService orderService;
 
-    // 주문 생성
+    // 주문 생성 (개인)
     @PostMapping
     public ResponseEntity<ApiResponse<Void>> createOrder(@AuthenticationPrincipal UserDetails userDetails) {
 
@@ -34,6 +34,16 @@ public class OrderController {
         return ResponseEntity.status(HttpStatus.CREATED)
                 .body(ApiResponse.of(null, OrderResponse.ORDER_CREATED.getMessage()));
     }
+
+    // 주문 생성 (공유)
+    @PostMapping("/{chatRoomId}")
+    public ResponseEntity<ApiResponse<Void>> createSharedOrder(@AuthenticationPrincipal UserDetails userDetails, @PathVariable Long chatRoomId) {
+
+        orderService.createSharedOrder(Long.valueOf(userDetails.getUsername()), chatRoomId);
+        return ResponseEntity.status(HttpStatus.CREATED)
+                .body(ApiResponse.of(null, OrderResponse.ORDER_CREATED.getMessage()));
+    }
+
 
     // 주문 목록 페이징 조회
     @GetMapping

--- a/src/main/java/com/example/eat_together/domain/order/entity/Order.java
+++ b/src/main/java/com/example/eat_together/domain/order/entity/Order.java
@@ -69,6 +69,15 @@ public class Order extends BaseTimeEntity {
         this.totalPrice = total;
     }
 
+    public void calculateSharedTotalPrice(double personalDeliveryFee) {
+        double total = 0;
+        for (OrderItem orderItem : orderItems) {
+            total += orderItem.getPrice() * orderItem.getQuantity();
+        }
+        total += personalDeliveryFee;
+        this.totalPrice = total;
+    }
+
     public void updateStatus(OrderStatus status) {
         this.status = status;
     }

--- a/src/main/java/com/example/eat_together/domain/order/service/OrderService.java
+++ b/src/main/java/com/example/eat_together/domain/order/service/OrderService.java
@@ -2,7 +2,13 @@ package com.example.eat_together.domain.order.service;
 
 import com.example.eat_together.domain.cart.entity.Cart;
 import com.example.eat_together.domain.cart.entity.CartItem;
+import com.example.eat_together.domain.cart.entity.SharedCart;
+import com.example.eat_together.domain.cart.entity.SharedCartItem;
 import com.example.eat_together.domain.cart.repository.CartRepository;
+import com.example.eat_together.domain.cart.repository.SharedCartRepository;
+import com.example.eat_together.domain.chat.chatEnum.MemberRole;
+import com.example.eat_together.domain.chat.entity.ChatRoom;
+import com.example.eat_together.domain.chat.entity.ChatRoomUser;
 import com.example.eat_together.domain.order.dto.response.OrderDetailResponseDto;
 import com.example.eat_together.domain.order.dto.response.OrderResponseDto;
 import com.example.eat_together.domain.order.dto.response.OrderStatusUpdateResponseDto;
@@ -28,6 +34,8 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDate;
 import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -37,8 +45,9 @@ public class OrderService {
     private final UserRepository userRepository;
     private final OrderCacheRepository orderCacheRepository;
     private final PaymentRepository paymentRepository;
+    private final SharedCartRepository sharedCartRepository;
 
-    // 주문 생성
+    // 주문 생성 (개인 장바구니)
     @Transactional
     public void createOrder(Long userId) {
 
@@ -73,6 +82,86 @@ public class OrderService {
 
         Payment payment = Payment.of(order);
         paymentRepository.save(payment);
+    }
+
+    // 주문 생성 (공유 장바구니)
+    @Transactional
+    public void createSharedOrder(Long userId, Long chatRoomId) {
+        // 장바구니가 있는지 조회
+        SharedCart sharedCart = sharedCartRepository.findByChatRoomId(chatRoomId)
+                .orElseThrow(() -> new CustomException(ErrorCode.CART_NOT_FOUND));
+
+        // 방장인지 확인
+        ChatRoom chatRoom = sharedCart.getChatRoom();
+        User host = chatRoom.getChatRoomUserList().stream()
+                .filter(cru -> cru.getMemberRole() == MemberRole.HOST)
+                .map(ChatRoomUser::getUser)
+                .findFirst()
+                .orElseThrow(() -> new CustomException(ErrorCode.NO_CHATROOM_LEADER));
+
+        if (!host.getUserId().equals(userId)) {
+            throw new CustomException(ErrorCode.FORBIDDEN_ACCESS);
+        }
+
+
+        if (sharedCart.getItems().isEmpty()) {
+            throw new CustomException(ErrorCode.CART_ITEM_NOT_FOUND);
+        }
+
+        // 채팅에 참여한 모든 멤버가 장바구니에 메뉴를 1개 이상 넣었는지 확인
+        Set<User> usersWithItems = sharedCart.getItems().stream()
+                .map(SharedCartItem::getUser)
+                .collect(Collectors.toSet());
+
+        for (ChatRoomUser cru : chatRoom.getChatRoomUserList()) {
+            if (!usersWithItems.contains(cru.getUser())) {
+                throw new CustomException(ErrorCode.CART_ITEM_NOT_FOUND);
+            }
+        }
+
+        // 참여자 목록 생성 및 가게 정보 조회
+        Store store = sharedCart.getItems().get(0).getMenu().getStore();
+
+        List<User> participants = sharedCart.getItems().stream()
+                .map(SharedCartItem::getUser)
+                .distinct()
+                .toList();
+
+        // 배송비 계산 및 설정
+        double deliveryFeePerUser = store.getDeliveryFee() / participants.size();
+
+        // 참여자별 주문 생성
+        for (User participant : participants) {
+            // 중복 주문 체크
+            List<Order> orderWithOrdered = orderRepository.findByUserIdAndStoreIdAndStatus(participant.getUserId(), store.getStoreId(), OrderStatus.ORDERED);
+            if (!orderWithOrdered.isEmpty()) {
+                throw new CustomException(ErrorCode.DUPLICATE_ORDER);
+            }
+
+            Order order = Order.of(participant, store);
+
+            boolean firstItem = true;
+            for (SharedCartItem item : sharedCart.getItems()) {
+                if (item.getUser().equals(participant)) {
+                    OrderItem orderItem = OrderItem.of(order, item.getMenu(), item.getQuantity());
+                    order.addOrderItem(orderItem);
+
+                    // 배송비는 첫 아이템에만 할당
+                    if (firstItem) {
+                        item.setDeliveryFeePerUser(deliveryFeePerUser);
+                        firstItem = false;
+                    } else {
+                        item.setDeliveryFeePerUser(0.0);
+                    }
+                }
+            }
+
+            order.calculateSharedTotalPrice(deliveryFeePerUser);
+            orderRepository.save(order);
+
+            Payment payment = Payment.of(order);
+            paymentRepository.save(payment);
+        }
     }
 
     // 주문 목록 조회
@@ -152,4 +241,6 @@ public class OrderService {
 
         order.deletedOrder();
     }
+
+
 }

--- a/src/main/java/com/example/eat_together/domain/payment/service/PaymentService.java
+++ b/src/main/java/com/example/eat_together/domain/payment/service/PaymentService.java
@@ -1,7 +1,6 @@
 package com.example.eat_together.domain.payment.service;
 
 import com.example.eat_together.domain.order.entity.Order;
-import com.example.eat_together.domain.order.repository.OrderRepository;
 import com.example.eat_together.domain.payment.dto.response.PaymentResponseDto;
 import com.example.eat_together.domain.payment.entity.Payment;
 import com.example.eat_together.domain.payment.paymentEnum.PaymentStatus;
@@ -16,7 +15,6 @@ import org.springframework.stereotype.Service;
 public class PaymentService {
 
     private final PaymentRepository paymentRepository;
-    private final OrderRepository orderRepository;
 
     public PaymentResponseDto confirmPayment(Long userId, Long paymentId) {
         Payment payment = paymentRepository.findById(paymentId)

--- a/src/main/java/com/example/eat_together/global/exception/ErrorCode.java
+++ b/src/main/java/com/example/eat_together/global/exception/ErrorCode.java
@@ -20,12 +20,13 @@ public enum ErrorCode {
     ORDER_PERIOD_MISMATCH(HttpStatus.BAD_REQUEST, "조회 시작일과 종료일은 함께 입력되어야 합니다."),
     INVALID_SESSION(HttpStatus.BAD_REQUEST, "유효하지 않은 세션입니다."),
     INVALID_URI(HttpStatus.BAD_REQUEST, "유효하지 않은 URI입니다."),
-    USER_NOT_DELETE(HttpStatus.BAD_REQUEST,"삭제되지 않은 유저입니다."),
+    USER_NOT_DELETE(HttpStatus.BAD_REQUEST, "삭제되지 않은 유저입니다."),
     CART_EXCEEDS_MAX_QUANTITY(HttpStatus.BAD_REQUEST, "메뉴는 최대 99개까지 담을 수 있습니다."),
     CART_INVALID_STORE(HttpStatus.BAD_REQUEST, "기존 장바구니와 다른 매장의 메뉴는 담을 수 없습니다."),
     ENTER_CHAT_ROOM_INAVAILABLE(HttpStatus.BAD_REQUEST, "제한 인원에 도달했거나 만료된 채팅방에 입장할 수 없습니다."),
     SOCIAL_NOCHANGE_PASSWORD(HttpStatus.BAD_REQUEST, "소셜 로그인 인원은 비밀번호 변경이 불가능 합니다."),
     ALREADY_PAID(HttpStatus.BAD_REQUEST, "이미 결제를 하였습니다."),
+    NO_CHATROOM_LEADER(HttpStatus.BAD_REQUEST, "채팅방 방장이 존재하지 않습니다"),
 
     // 403 FORBIDDEN
     ADMIN_ACCOUNT_CANNOT_BE_DELETED(HttpStatus.FORBIDDEN, "관리자 계정은 삭제할 수 없습니다."),


### PR DESCRIPTION
## 이슈 번호
#168 
## 작업 내용
- 공유 장바구니용 주문 API를 추가하였습니다.
- 공유 장바구니 주문과 일반 장바구니 주문의 결제 API는 동일하게 처리됩니다.
## 스크린샷(선택)
