### PR TITLE
[Feat] 채팅 조회 redis 캐싱 적용 (#174)

### DIFF
--- a/src/main/java/com/example/eat_together/domain/chat/controller/ChatManageController.java
+++ b/src/main/java/com/example/eat_together/domain/chat/controller/ChatManageController.java
@@ -6,6 +6,7 @@ import com.example.eat_together.domain.chat.dto.ChatGroupCreateRequestDto;
 import com.example.eat_together.domain.chat.dto.ChatGroupUpdateRequestDto;
 import com.example.eat_together.domain.chat.dto.ChatMessageResponseDto;
 import com.example.eat_together.domain.chat.dto.ChatRoomDto;
+import com.example.eat_together.domain.chat.service.ChatMessageRedisService;
 import com.example.eat_together.domain.chat.service.ChatService;
 import com.example.eat_together.global.dto.ApiResponse;
 import jakarta.validation.Valid;
@@ -22,6 +23,7 @@ import java.util.List;
 @RequestMapping("/chats")
 public class ChatManageController {
     private final ChatService chatService;
+    private final ChatMessageRedisService chatMessageRedisService;
 
     //채팅방 생성
     @PostMapping()
@@ -74,8 +76,15 @@ public class ChatManageController {
     }
 
     //기존 채팅 내역 조회
-    @GetMapping("/{roomId}")
+    @GetMapping("/{roomId}/v2")
     public ResponseEntity<ApiResponse<List<ChatMessageResponseDto>>> getChatMessageList(@PathVariable Long roomId) {
+        List<ChatMessageResponseDto> chatMessageList = chatMessageRedisService.getMessageList(roomId);
+
+        return ResponseEntity.ok(ApiResponse.of(chatMessageList, ChatResponse.READ_CHAT_MESSAGE_LIST.getMessage()));
+    }
+
+    @GetMapping("/{roomId}/v1")
+    public ResponseEntity<ApiResponse<List<ChatMessageResponseDto>>> getChatMessageListV1(@PathVariable Long roomId) {
         List<ChatMessageResponseDto> chatMessageList = chatService.getChatMessageList(roomId);
 
         return ResponseEntity.ok(ApiResponse.of(chatMessageList, ChatResponse.READ_CHAT_MESSAGE_LIST.getMessage()));

--- a/src/main/java/com/example/eat_together/domain/chat/repository/ChatMessageRedisRepository.java
+++ b/src/main/java/com/example/eat_together/domain/chat/repository/ChatMessageRedisRepository.java
@@ -1,0 +1,24 @@
+package com.example.eat_together.domain.chat.repository;
+
+import com.example.eat_together.domain.chat.dto.ChatMessageResponseDto;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Repository;
+
+import java.time.Duration;
+import java.util.List;
+
+@Repository
+@RequiredArgsConstructor
+public class ChatMessageRedisRepository {
+
+    private final RedisTemplate<String, ChatMessageResponseDto> chatMessageResponseDtoRedisTemplate;
+
+    public void saveChatMessage(List<ChatMessageResponseDto> chatMessageResponseDtoList, String CHAT_CACHE_KEY, Duration TTL) {
+
+        chatMessageResponseDtoRedisTemplate.delete(CHAT_CACHE_KEY);
+        chatMessageResponseDtoRedisTemplate.opsForList().rightPushAll(CHAT_CACHE_KEY, chatMessageResponseDtoList);
+        chatMessageResponseDtoRedisTemplate.expire(CHAT_CACHE_KEY, TTL);
+
+    }
+}

--- a/src/main/java/com/example/eat_together/domain/chat/service/ChatMessageRedisService.java
+++ b/src/main/java/com/example/eat_together/domain/chat/service/ChatMessageRedisService.java
@@ -1,0 +1,46 @@
+package com.example.eat_together.domain.chat.service;
+
+import com.example.eat_together.domain.chat.dto.ChatMessageResponseDto;
+import com.example.eat_together.domain.chat.entity.ChatMessage;
+import com.example.eat_together.domain.chat.repository.ChatMessageRedisRepository;
+import com.example.eat_together.domain.chat.repository.ChatMessageRepository;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Service;
+
+import java.time.Duration;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class ChatMessageRedisService {
+
+    private final ChatMessageRepository chatMessageRepository;
+    private final ChatMessageRedisRepository chatMessageRedisRepository;
+    private final RedisTemplate<String, ChatMessageResponseDto> chatMessageResponseDtoRedisTemplate;
+    private static final Duration TTL = Duration.ofDays(1L);
+
+    @Transactional
+    public List<ChatMessageResponseDto> getMessageList(Long roomId) {
+
+        String CHAT_CACHE_KEY = "roomId:" + roomId;
+        List<ChatMessageResponseDto> cached = chatMessageResponseDtoRedisTemplate.opsForList().range(CHAT_CACHE_KEY, 0, -1);
+
+        if (cached == null || cached.isEmpty()) {
+            List<ChatMessage> chatMessageList = chatMessageRepository.findByChatRoomId(roomId);
+            List<ChatMessageResponseDto> chatMessageResponseDtoList = chatMessageList.stream()
+                    .map(chatMessage -> ChatMessageResponseDto
+                            .of(chatMessage.getUser().getUserId(),
+                                    chatMessage.getChatRoom().getId(),
+                                    chatMessage.getMessage()
+                            )).toList();
+            chatMessageRedisRepository.saveChatMessage(chatMessageResponseDtoList, CHAT_CACHE_KEY, TTL);
+
+            return chatMessageResponseDtoList;
+        }
+
+        return cached;
+    }
+
+}

--- a/src/main/java/com/example/eat_together/global/config/CacheConfig.java
+++ b/src/main/java/com/example/eat_together/global/config/CacheConfig.java
@@ -1,5 +1,6 @@
 package com.example.eat_together.global.config;
 
+import com.example.eat_together.domain.chat.dto.ChatMessageResponseDto;
 import com.example.eat_together.domain.menu.dto.respones.MenuResponseDto;
 import com.example.eat_together.domain.menu.dto.respones.PagingMenuResponseDto;
 import com.example.eat_together.domain.order.dto.response.OrderDetailResponseDto;
@@ -8,6 +9,7 @@ import com.example.eat_together.domain.store.dto.response.StoreResponseDto;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import org.springframework.cache.annotation.EnableCaching;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.data.redis.connection.RedisConnectionFactory;
@@ -15,6 +17,7 @@ import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.data.redis.serializer.Jackson2JsonRedisSerializer;
 import org.springframework.data.redis.serializer.StringRedisSerializer;
 
+@EnableCaching
 @Configuration
 public class CacheConfig {
 
@@ -26,83 +29,58 @@ public class CacheConfig {
                 .disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS); // TimeStamp를 문자열로 저장
     }
 
-    // 메뉴 단건 조회 Redis 설정
-    @Bean
-    public RedisTemplate<String, MenuResponseDto> menuRedisTemplate(RedisConnectionFactory connectionFactory) {
-        RedisTemplate<String, MenuResponseDto> template = new RedisTemplate<>();
+    private <T>RedisTemplate<String, T> genericRedisTemplate(RedisConnectionFactory connectionFactory, Class<T> clazz) {
+        RedisTemplate<String, T> template = new RedisTemplate<>();
         template.setConnectionFactory(connectionFactory);
         template.setKeySerializer(new StringRedisSerializer());
 
-        Jackson2JsonRedisSerializer<MenuResponseDto> serializer =
-                new Jackson2JsonRedisSerializer<>(MenuResponseDto.class);
+        Jackson2JsonRedisSerializer<T> serializer =
+                new Jackson2JsonRedisSerializer<>(objectMapper(), clazz);
 
-        serializer.setObjectMapper(objectMapper());
         template.setValueSerializer(serializer);
         template.afterPropertiesSet();
         return template;
+    }
+
+    // 메뉴 단건 조회 Redis 설정
+    @Bean
+    public RedisTemplate<String, MenuResponseDto> menuRedisTemplate(RedisConnectionFactory connectionFactory) {
+
+        return genericRedisTemplate(connectionFactory, MenuResponseDto.class);
     }
 
     // 매장 메뉴 목록 조회 Redis 설정
     @Bean
     public RedisTemplate<String, PagingMenuResponseDto> pagingMenuRedisTemplate(RedisConnectionFactory connectionFactory) {
-        RedisTemplate<String, PagingMenuResponseDto> template = new RedisTemplate<>();
-        template.setConnectionFactory(connectionFactory);
-        template.setKeySerializer(new StringRedisSerializer());
 
-        Jackson2JsonRedisSerializer<PagingMenuResponseDto> serializer =
-                new Jackson2JsonRedisSerializer<>(PagingMenuResponseDto.class);
-
-        serializer.setObjectMapper(objectMapper());
-        template.setValueSerializer(serializer);
-        template.afterPropertiesSet();
-        return template;
+        return genericRedisTemplate(connectionFactory, PagingMenuResponseDto.class);
     }
 
     // 매장 단건 조회 Redis 설정
     @Bean
     public RedisTemplate<String, StoreResponseDto> storeRedisTemplate(RedisConnectionFactory connectionFactory) {
-        RedisTemplate<String, StoreResponseDto> template = new RedisTemplate<>();
-        template.setConnectionFactory(connectionFactory);
-        template.setKeySerializer(new StringRedisSerializer());
 
-        Jackson2JsonRedisSerializer<StoreResponseDto> serializer =
-                new Jackson2JsonRedisSerializer<>(StoreResponseDto.class);
-
-        serializer.setObjectMapper(objectMapper());
-        template.setValueSerializer(serializer);
-        template.afterPropertiesSet();
-        return template;
+        return genericRedisTemplate(connectionFactory, StoreResponseDto.class);
     }
 
     // 매장 목록 조회 Redis 설정
     @Bean
     public RedisTemplate<String, PagingStoreResponseDto> pagingStoreRedisTemplate(RedisConnectionFactory connectionFactory) {
-        RedisTemplate<String, PagingStoreResponseDto> template = new RedisTemplate<>();
-        template.setConnectionFactory(connectionFactory);
-        template.setKeySerializer(new StringRedisSerializer());
 
-        Jackson2JsonRedisSerializer<PagingStoreResponseDto> serializer =
-                new Jackson2JsonRedisSerializer<>(PagingStoreResponseDto.class);
-
-        serializer.setObjectMapper(objectMapper());
-        template.setValueSerializer(serializer);
-        template.afterPropertiesSet();
-        return template;
+        return genericRedisTemplate(connectionFactory, PagingStoreResponseDto.class);
     }
 
     // 주문 단건 조회 Redis 설정
     @Bean
     public RedisTemplate<String, OrderDetailResponseDto> orderDetailResponseDtoRedisTemplate(RedisConnectionFactory connectionFactory) {
-        RedisTemplate<String, OrderDetailResponseDto> template = new RedisTemplate<>();
-        template.setConnectionFactory(connectionFactory);
-        template.setKeySerializer(new StringRedisSerializer());
 
-        Jackson2JsonRedisSerializer<OrderDetailResponseDto> serializer =
-                new Jackson2JsonRedisSerializer<>(OrderDetailResponseDto.class);
+        return genericRedisTemplate(connectionFactory, OrderDetailResponseDto.class);
+    }
 
-        serializer.setObjectMapper(objectMapper());
-        template.setValueSerializer(serializer);
-        template.afterPropertiesSet();
-        return template;
+    // 채팅 조회 Redis 설정
+    @Bean
+    public RedisTemplate<String, ChatMessageResponseDto> chatMessageResponseDtoRedisTemplate(RedisConnectionFactory connectionFactory) {
+
+        return genericRedisTemplate(connectionFactory, ChatMessageResponseDto.class);
     }
 }


### PR DESCRIPTION
## 이슈 번호
#174 

## 작업 내용
- 채팅 조회 시 redis 캐싱 적용(v2)
- 기존 조회 방법도 삭제하지 않고 유지: 속도 차이 보여주기 위해서(v1)
- 파라미터만 다른 반복되는 메서드 제네릭으로 정리

## 스크린샷(선택)
