### PR TITLE
[feature] 비회원 장바구니 CRUD 및 Redis 적용, 로그인 시 장바구니 병합, 공유 장바구니 접근 제어, javadoc 주석 추가(#181)

### DIFF
--- a/src/main/java/com/example/eat_together/domain/cart/controller/CartController.java
+++ b/src/main/java/com/example/eat_together/domain/cart/controller/CartController.java
@@ -13,11 +13,14 @@ import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.web.bind.annotation.*;
 
 /**
- * 장바구니 관련 요청 처리하는 컨트롤러
+ * {@code CartController}
+ * 로그인 사용자의 장바구니 기능을 처리하는 컨트롤러
+ * <p>
+ * 장바구니 항목 추가, 조회, 수량 수정, 삭제 기능 제공
+ * </p>
  */
 @RestController
 @RequiredArgsConstructor
-@RequestMapping
 public class CartController {
 
     private final CartService cartService;
@@ -28,7 +31,7 @@ public class CartController {
      * @param userDetails 로그인 사용자 정보
      * @param storeId     매장 ID
      * @param requestDto  메뉴 및 수량 정보
-     * @return 생성 완료 응답
+     * @return HTTP 201(Created) 상태 코드와 추가 완료 응답
      */
     @PostMapping("/stores/{storeId}/carts/items")
     public ResponseEntity<ApiResponse<Void>> addItem(
@@ -42,10 +45,10 @@ public class CartController {
     }
 
     /**
-     * 장바구니 조회
+     * 로그인 사용자의 장바구니 조회
      *
      * @param userDetails 로그인 사용자 정보
-     * @return 장바구니 응답 데이터
+     * @return 장바구니 데이터와 조회 완료 응답
      */
     @GetMapping("/carts/me")
     public ResponseEntity<ApiResponse<CartResponseDto>> getCart(
@@ -59,7 +62,7 @@ public class CartController {
      * 장바구니 항목 수량 수정
      *
      * @param itemId     수정할 항목 ID
-     * @param requestDto 수정할 수량 정보
+     * @param requestDto 변경할 수량 정보
      * @return 수정 완료 응답
      */
     @PatchMapping("/carts/items/{itemId}")

--- a/src/main/java/com/example/eat_together/domain/cart/controller/GuestCartController.java
+++ b/src/main/java/com/example/eat_together/domain/cart/controller/GuestCartController.java
@@ -1,0 +1,163 @@
+package com.example.eat_together.domain.cart.controller;
+
+import com.example.eat_together.domain.cart.dto.request.CartItemRequestDto;
+import com.example.eat_together.domain.cart.dto.response.CartResponseDto;
+import com.example.eat_together.domain.cart.service.GuestCartService;
+import com.example.eat_together.global.dto.ApiResponse;
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseCookie;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.Arrays;
+import java.util.Optional;
+import java.util.UUID;
+
+/**
+ * {@code GuestCartController}
+ * 비회원(게스트) 장바구니 기능을 처리하는 컨트롤러
+ * <p>
+ * 게스트 사용자는 UUID 기반 식별자를 쿠키로 발급받아 장바구니 유지
+ * 로그인 또는 회원가입 시 게스트 장바구니를 회원 장바구니와 병합 가능
+ * </p>
+ */
+@RestController
+@RequiredArgsConstructor
+public class GuestCartController {
+
+    /**
+     * 게스트 장바구니 식별자 쿠키명
+     */
+    private static final String COOKIE_NAME = "GUEST_CART_ID";
+
+    private final GuestCartService guestCartService;
+
+    /**
+     * 게스트 ID를 쿠키에서 조회하거나, 없으면 발급 후 쿠키에 저장
+     *
+     * @param req HTTP 요청 객체
+     * @param res HTTP 응답 객체
+     * @return 게스트 장바구니 식별자(UUID)
+     */
+    private String getOrIssueGuestId(HttpServletRequest req, HttpServletResponse res) {
+        if (req.getCookies() != null) {
+            Optional<String> existing = Arrays.stream(req.getCookies())
+                    .filter(c -> COOKIE_NAME.equals(c.getName()))
+                    .map(Cookie::getValue)
+                    .findFirst();
+            if (existing.isPresent()) return existing.get();
+        }
+        String uuid = UUID.randomUUID().toString();
+        ResponseCookie cookie = ResponseCookie.from(COOKIE_NAME, uuid)
+                .httpOnly(true)
+                .path("/")
+                .maxAge(60L * 60 * 24 * 14) // 14일
+                .sameSite("Lax")
+                .build();
+        res.addHeader("Set-Cookie", cookie.toString());
+        return uuid;
+    }
+
+    /**
+     * 게스트 장바구니에 항목 추가
+     *
+     * @param req     HTTP 요청 객체
+     * @param res     HTTP 응답 객체
+     * @param storeId 매장 ID
+     * @param dto     메뉴 및 수량 정보
+     * @return 추가 완료 응답
+     */
+    @PostMapping("/stores/{storeId}/guest-carts/items")
+    public ResponseEntity<ApiResponse<Void>> addItem(
+            HttpServletRequest req, HttpServletResponse res,
+            @PathVariable Long storeId,
+            @RequestBody CartItemRequestDto dto
+    ) {
+        String gid = getOrIssueGuestId(req, res);
+        guestCartService.addItem(gid, storeId, dto);
+        return ResponseEntity.ok(ApiResponse.of(null, "게스트 장바구니에 담았습니다."));
+    }
+
+    /**
+     * 게스트 장바구니 조회 (쿠키 기준)
+     *
+     * @param req HTTP 요청 객체
+     * @param res HTTP 응답 객체
+     * @return 장바구니 데이터와 조회 완료 응답
+     */
+    @GetMapping("/guest-carts/me")
+    public ResponseEntity<ApiResponse<CartResponseDto>> getCart(
+            HttpServletRequest req, HttpServletResponse res
+    ) {
+        String gid = getOrIssueGuestId(req, res);
+        CartResponseDto dto = guestCartService.getCart(gid);
+        return ResponseEntity.ok(ApiResponse.of(dto, "게스트 장바구니 조회"));
+    }
+
+    /**
+     * 게스트 장바구니의 특정 메뉴 수량 변경
+     *
+     * @param req      HTTP 요청 객체
+     * @param res      HTTP 응답 객체
+     * @param menuId   메뉴 ID
+     * @param quantity 변경할 수량
+     * @return 수량 변경 완료 응답
+     */
+    @PatchMapping("/guest-carts/items/{menuId}")
+    public ResponseEntity<ApiResponse<Void>> update(
+            HttpServletRequest req, HttpServletResponse res,
+            @PathVariable Long menuId,
+            @RequestParam int quantity
+    ) {
+        String gid = getOrIssueGuestId(req, res);
+        guestCartService.updateItem(gid, menuId, quantity);
+        return ResponseEntity.ok(ApiResponse.of(null, "수량 변경"));
+    }
+
+    /**
+     * 게스트 장바구니에서 특정 메뉴 삭제
+     *
+     * @param req    HTTP 요청 객체
+     * @param res    HTTP 응답 객체
+     * @param menuId 삭제할 메뉴 ID
+     * @return 삭제 완료 응답
+     */
+    @DeleteMapping("/guest-carts/items/{menuId}")
+    public ResponseEntity<ApiResponse<Void>> delete(
+            HttpServletRequest req, HttpServletResponse res,
+            @PathVariable Long menuId
+    ) {
+        String gid = getOrIssueGuestId(req, res);
+        guestCartService.deleteItem(gid, menuId);
+        return ResponseEntity.ok(ApiResponse.of(null, "삭제 완료"));
+    }
+
+    /**
+     * 로그인 또는 회원가입 직후 게스트 장바구니를 회원 장바구니와 병합
+     *
+     * @param userDetails 로그인 사용자 정보
+     * @param req         HTTP 요청 객체
+     * @return 병합 완료 응답
+     */
+    @PostMapping("/guest-carts/merge")
+    public ResponseEntity<ApiResponse<Void>> merge(
+            @AuthenticationPrincipal UserDetails userDetails,
+            HttpServletRequest req
+    ) {
+        String gid = Arrays.stream(Optional.ofNullable(req.getCookies()).orElse(new Cookie[0]))
+                .filter(c -> COOKIE_NAME.equals(c.getName()))
+                .map(Cookie::getValue)
+                .findFirst()
+                .orElse(null);
+        if (gid != null) {
+            Long userId = Long.valueOf(userDetails.getUsername());
+            guestCartService.mergeToUserCart(gid, userId);
+        }
+        return ResponseEntity.ok(ApiResponse.of(null, "게스트 장바구니 머지 완료"));
+    }
+}

--- a/src/main/java/com/example/eat_together/domain/cart/controller/SharedCartController.java
+++ b/src/main/java/com/example/eat_together/domain/cart/controller/SharedCartController.java
@@ -12,6 +12,14 @@ import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.web.bind.annotation.*;
 
+/**
+ * {@code SharedCartController}
+ * 채팅방 기반의 공유 장바구니 기능을 처리하는 컨트롤러
+ * <p>
+ * 채팅방 참여자들이 동일한 매장에서 주문할 메뉴를 공유 장바구니에 담고
+ * 조회, 수량 수정, 삭제할 수 있는 기능 제공
+ * </p>
+ */
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/chats/{roomId}/stores/{storeId}/shared-carts")
@@ -19,6 +27,15 @@ public class SharedCartController {
 
     private final SharedCartService sharedCartService;
 
+    /**
+     * 공유 장바구니에 메뉴 항목 추가
+     *
+     * @param userDetails 로그인 사용자 정보
+     * @param roomId      채팅방 ID
+     * @param storeId     매장 ID
+     * @param requestDto  메뉴 및 수량 정보
+     * @return HTTP 201(Created) 상태 코드와 추가 완료 응답
+     */
     @PostMapping("/items")
     public ResponseEntity<ApiResponse<Void>> addItem(
             @AuthenticationPrincipal UserDetails userDetails,
@@ -32,15 +49,35 @@ public class SharedCartController {
                 .body(ApiResponse.of(null, "공유 장바구니에 메뉴가 추가되었습니다."));
     }
 
+    /**
+     * 공유 장바구니 항목 전체 조회
+     *
+     * @param userDetails 로그인 사용자 정보
+     * @param roomId      채팅방 ID
+     * @param storeId     매장 ID
+     * @return 공유 장바구니 전체 항목과 조회 완료 응답
+     */
     @GetMapping("/items")
     public ResponseEntity<ApiResponse<SharedCartResponseDto>> getAllItems(
+            @AuthenticationPrincipal UserDetails userDetails,
             @PathVariable Long roomId,
             @PathVariable Long storeId
     ) {
-        SharedCartResponseDto response = sharedCartService.getSharedCartItems(roomId);
+        Long userId = Long.valueOf(userDetails.getUsername());
+        SharedCartResponseDto response = sharedCartService.getSharedCartItems(userId, roomId);
         return ResponseEntity.ok(ApiResponse.of(response, "공유 장바구니 항목을 조회했습니다."));
     }
 
+    /**
+     * 공유 장바구니의 특정 항목 수량 수정
+     *
+     * @param userDetails 로그인 사용자 정보
+     * @param roomId      채팅방 ID
+     * @param storeId     매장 ID
+     * @param itemId      항목 ID
+     * @param requestDto  변경할 수량 정보
+     * @return 수량 수정 완료 응답
+     */
     @PatchMapping("/items/{itemId}")
     public ResponseEntity<ApiResponse<Void>> updateItemQuantity(
             @AuthenticationPrincipal UserDetails userDetails,
@@ -54,6 +91,15 @@ public class SharedCartController {
         return ResponseEntity.ok(ApiResponse.of(null, "공유 장바구니 항목 수량이 수정되었습니다."));
     }
 
+    /**
+     * 공유 장바구니에서 특정 항목 삭제
+     *
+     * @param userDetails 로그인 사용자 정보
+     * @param roomId      채팅방 ID
+     * @param storeId     매장 ID
+     * @param itemId      항목 ID
+     * @return 삭제 완료 응답
+     */
     @DeleteMapping("/items/{itemId}")
     public ResponseEntity<ApiResponse<Void>> deleteItem(
             @AuthenticationPrincipal UserDetails userDetails,
@@ -65,5 +111,6 @@ public class SharedCartController {
         sharedCartService.deleteItem(userId, roomId, itemId);
         return ResponseEntity.ok(ApiResponse.of(null, "공유 장바구니 항목이 삭제되었습니다."));
     }
-
 }
+
+

--- a/src/main/java/com/example/eat_together/domain/cart/dto/request/SharedCartItemRequestDto.java
+++ b/src/main/java/com/example/eat_together/domain/cart/dto/request/SharedCartItemRequestDto.java
@@ -6,14 +6,25 @@ import jakarta.validation.constraints.NotNull;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+/**
+ * 공유 장바구니에 담을 메뉴 항목 요청 정보를 담는 DTO
+ */
 @Getter
 @NoArgsConstructor
 public class SharedCartItemRequestDto {
 
-    @NotNull(message = "메뉴 ID는 필수입니다.")
+    /**
+     * 메뉴 ID
+     * - 필수 값
+     */
+    @NotNull(message = "메뉴 ID는 필수")
     private Long menuId;
 
-    @Min(value = 1, message = "수량은 최소 1 이상이어야 합니다.")
-    @Max(value = 99, message = "수량은 최대 99까지 허용됩니다.")
+    /**
+     * 수량
+     * - 최소 1 이상, 최대 99 이하
+     */
+    @Min(value = 1, message = "수량은 최소 1 이상")
+    @Max(value = 99, message = "수량은 최대 99까지 허용")
     private int quantity;
 }

--- a/src/main/java/com/example/eat_together/domain/cart/dto/response/CartItemResponseDto.java
+++ b/src/main/java/com/example/eat_together/domain/cart/dto/response/CartItemResponseDto.java
@@ -17,6 +17,12 @@ public class CartItemResponseDto {
     private final double price;
     private final double totalPrice;
 
+    /**
+     * {@link CartItem} 엔티티를 기반으로 {@code CartItemResponseDto} 생성
+     *
+     * @param cartItem 장바구니 항목 엔티티
+     * @return 변환된 DTO 객체
+     */
     public static CartItemResponseDto from(CartItem cartItem) {
         return CartItemResponseDto.builder()
                 .itemId(cartItem.getId())

--- a/src/main/java/com/example/eat_together/domain/cart/dto/response/CartResponseDto.java
+++ b/src/main/java/com/example/eat_together/domain/cart/dto/response/CartResponseDto.java
@@ -1,22 +1,30 @@
 package com.example.eat_together.domain.cart.dto.response;
 
 import com.example.eat_together.domain.cart.entity.Cart;
-import com.example.eat_together.domain.cart.entity.CartItem;
 import lombok.Builder;
 import lombok.Getter;
 
 import java.util.List;
 
+/**
+ * 장바구니 응답 정보를 담는 DTO
+ */
 @Getter
 @Builder
 public class CartResponseDto {
 
     private Long storeId;
     private List<CartItemResponseDto> content;
-    private double subPrice;         // 메뉴 총합
-    private double deliveryFee;      // 배달팁 (개인 주문이면 전체, 공유에서 복사 시 개인분담)
-    private double storeTotalPrice;  // 전체 금액 = 메뉴 합계 + 배달팁
+    private double subPrice;
+    private double deliveryFee;
+    private double storeTotalPrice;
 
+    /**
+     * {@link Cart} 엔티티를 기반으로 {@code CartResponseDto} 생성
+     *
+     * @param cart 장바구니 엔티티
+     * @return 변환된 DTO 객체
+     */
     public static CartResponseDto of(Cart cart) {
         List<CartItemResponseDto> items = cart.getCartItems().stream()
                 .map(CartItemResponseDto::from)

--- a/src/main/java/com/example/eat_together/domain/cart/dto/response/SharedCartItemResponseDto.java
+++ b/src/main/java/com/example/eat_together/domain/cart/dto/response/SharedCartItemResponseDto.java
@@ -5,6 +5,9 @@ import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import lombok.Builder;
 import lombok.Getter;
 
+/**
+ * 공유 장바구니 항목 응답 정보를 담는 DTO
+ */
 @Getter
 @JsonPropertyOrder({
         "userName",
@@ -40,6 +43,13 @@ public class SharedCartItemResponseDto {
         this.totalPrice = totalPrice;
     }
 
+    /**
+     * {@link SharedCartItem} 엔티티를 기반으로 {@code SharedCartItemResponseDto} 생성
+     *
+     * @param item               공유 장바구니 항목 엔티티
+     * @param deliveryFeePerUser 해당 항목에 부과되는 개인 배달비
+     * @return 변환된 DTO 객체
+     */
     public static SharedCartItemResponseDto from(SharedCartItem item, double deliveryFeePerUser) {
         double total = item.getMenu().getPrice() * item.getQuantity() + deliveryFeePerUser;
         return SharedCartItemResponseDto.builder()

--- a/src/main/java/com/example/eat_together/domain/cart/dto/response/SharedCartResponseDto.java
+++ b/src/main/java/com/example/eat_together/domain/cart/dto/response/SharedCartResponseDto.java
@@ -5,6 +5,9 @@ import lombok.Getter;
 
 import java.util.List;
 
+/**
+ * 공유 장바구니 응답 정보를 담는 DTO
+ */
 @Getter
 @Builder
 public class SharedCartResponseDto {

--- a/src/main/java/com/example/eat_together/domain/cart/entity/Cart.java
+++ b/src/main/java/com/example/eat_together/domain/cart/entity/Cart.java
@@ -10,7 +10,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 /**
- * 사용자 장바구니를 나타내는 엔티티
+ * 사용자 장바구니 엔티티
  */
 @Entity
 @Getter
@@ -29,16 +29,11 @@ public class Cart extends BaseTimeEntity {
     @OneToMany(mappedBy = "cart", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<CartItem> cartItems = new ArrayList<>();
 
-    /**
-     * 배달팁 (기본값 0)
-     * - 개인 주문 시 전체 배달팁
-     * - 공유 복사 시 사용자 분담 배달팁
-     */
     @Column(nullable = false)
     private double deliveryFee = 0.0;
 
     /**
-     * Cart 생성 정적 팩토리 메서드
+     * Cart 인스턴스 생성
      *
      * @param user 사용자 엔티티
      * @return 생성된 Cart 인스턴스
@@ -50,9 +45,9 @@ public class Cart extends BaseTimeEntity {
     }
 
     /**
-     * 장바구니 항목 추가
+     * 장바구니에 항목 추가
      *
-     * @param cartItem 추가할 항목
+     * @param cartItem 추가할 장바구니 항목
      */
     public void addCartItem(CartItem cartItem) {
         cartItems.add(cartItem);
@@ -60,14 +55,16 @@ public class Cart extends BaseTimeEntity {
     }
 
     /**
-     * 장바구니 항목 전체 비우기
+     * 장바구니 항목 전체 삭제
      */
     public void clearItems() {
         cartItems.clear();
     }
 
     /**
-     * 배달팁 설정
+     * 배달팁 변경
+     *
+     * @param deliveryFee 배달팁 금액
      */
     public void setDeliveryFee(double deliveryFee) {
         this.deliveryFee = deliveryFee;

--- a/src/main/java/com/example/eat_together/domain/cart/entity/CartItem.java
+++ b/src/main/java/com/example/eat_together/domain/cart/entity/CartItem.java
@@ -7,7 +7,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 /**
- * 장바구니에 담긴 단일 메뉴 항목을 나타내는 엔티티
+ * 장바구니에 담긴 단일 메뉴 항목 엔티티
  */
 @Entity
 @Getter
@@ -30,9 +30,9 @@ public class CartItem extends BaseTimeEntity {
     private int quantity;
 
     /**
-     * CartItem 생성 정적 팩토리 메서드
+     * CartItem 인스턴스 생성
      *
-     * @param menu     메뉴 정보
+     * @param menu     메뉴 엔티티
      * @param quantity 수량
      * @return 생성된 CartItem 인스턴스
      */
@@ -44,7 +44,7 @@ public class CartItem extends BaseTimeEntity {
     }
 
     /**
-     * 장바구니 연관 관계 설정
+     * 장바구니 연관관계 설정
      *
      * @param cart 장바구니 엔티티
      */
@@ -64,7 +64,7 @@ public class CartItem extends BaseTimeEntity {
     /**
      * 총 가격 계산
      *
-     * @return 메뉴 가격 * 수량 결과
+     * @return 메뉴 가격 × 수량
      */
     public double getTotalPrice() {
         return menu.getPrice() * quantity;

--- a/src/main/java/com/example/eat_together/domain/cart/entity/SharedCart.java
+++ b/src/main/java/com/example/eat_together/domain/cart/entity/SharedCart.java
@@ -8,6 +8,9 @@ import lombok.NoArgsConstructor;
 import java.util.ArrayList;
 import java.util.List;
 
+/**
+ * 채팅방 기반 공유 장바구니 엔티티
+ */
 @Entity
 @Getter
 @NoArgsConstructor
@@ -28,10 +31,21 @@ public class SharedCart {
         this.chatRoom = chatRoom;
     }
 
+    /**
+     * SharedCart 인스턴스 생성
+     *
+     * @param chatRoom 공유 장바구니가 속한 채팅방
+     * @return 생성된 SharedCart 인스턴스
+     */
     public static SharedCart of(ChatRoom chatRoom) {
         return new SharedCart(chatRoom);
     }
 
+    /**
+     * 공유 장바구니에 항목 추가
+     *
+     * @param item 추가할 항목
+     */
     public void addItem(SharedCartItem item) {
         items.add(item);
         item.setSharedCart(this);

--- a/src/main/java/com/example/eat_together/domain/cart/entity/SharedCartItem.java
+++ b/src/main/java/com/example/eat_together/domain/cart/entity/SharedCartItem.java
@@ -6,6 +6,9 @@ import jakarta.persistence.*;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+/**
+ * 공유 장바구니에 담긴 단일 메뉴 항목 엔티티
+ */
 @Entity
 @Getter
 @NoArgsConstructor
@@ -17,7 +20,7 @@ public class SharedCartItem {
 
     private int quantity;
 
-    private double deliveryFeePerUser; // 🆕 개인 배달팁
+    private double deliveryFeePerUser;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "menu_id")
@@ -37,23 +40,51 @@ public class SharedCartItem {
         this.quantity = quantity;
     }
 
+    /**
+     * SharedCartItem 인스턴스 생성
+     *
+     * @param menu     메뉴 엔티티
+     * @param user     사용자 엔티티
+     * @param quantity 수량
+     * @return 생성된 SharedCartItem 인스턴스
+     */
     public static SharedCartItem of(Menu menu, User user, int quantity) {
         return new SharedCartItem(menu, user, quantity);
     }
 
+    /**
+     * 공유 장바구니 연관관계 설정
+     *
+     * @param sharedCart 공유 장바구니 엔티티
+     */
     public void setSharedCart(SharedCart sharedCart) {
         this.sharedCart = sharedCart;
     }
 
+    /**
+     * 수량 변경
+     *
+     * @param quantity 변경할 수량
+     */
     public void updateQuantity(int quantity) {
         this.quantity = quantity;
     }
 
+    /**
+     * 총 가격 계산 (메뉴 가격 × 수량 + 개인 배달팁)
+     *
+     * @return 총 가격
+     */
     public double getTotalPrice() {
         return menu.getPrice() * quantity + deliveryFeePerUser;
     }
 
-    public void setDeliveryFeePerUser(double Fee) {
-        this.deliveryFeePerUser = Fee;
+    /**
+     * 개인 배달팁 변경
+     *
+     * @param fee 변경할 배달팁 금액
+     */
+    public void setDeliveryFeePerUser(double fee) {
+        this.deliveryFeePerUser = fee;
     }
 }

--- a/src/main/java/com/example/eat_together/domain/cart/repository/GuestCartRepository.java
+++ b/src/main/java/com/example/eat_together/domain/cart/repository/GuestCartRepository.java
@@ -1,0 +1,96 @@
+package com.example.eat_together.domain.cart.repository;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.stereotype.Repository;
+
+import java.time.Duration;
+import java.util.Map;
+
+/**
+ * 비회원(게스트) 장바구니 데이터를 Redis에 저장하고 조회하는 저장소
+ */
+@Repository
+@RequiredArgsConstructor
+public class GuestCartRepository {
+
+    private static final Duration TTL = Duration.ofDays(14);
+    private final StringRedisTemplate redis;
+
+    private String keyStore(Long guestIdHash) {
+        return "guest:cart:%d:store".formatted(guestIdHash);
+    }
+
+    private String keyItems(Long guestIdHash) {
+        return "guest:cart:%d:items".formatted(guestIdHash);
+    }
+
+    /**
+     * 매장 ID 저장
+     *
+     * @param guestIdHash 게스트 ID 해시값
+     * @param storeId     매장 ID
+     */
+    public void setStore(Long guestIdHash, Long storeId) {
+        redis.opsForValue().set(keyStore(guestIdHash), String.valueOf(storeId), TTL);
+    }
+
+    /**
+     * 매장 ID 조회
+     *
+     * @param guestIdHash 게스트 ID 해시값
+     * @return 매장 ID 또는 null
+     */
+    public Long getStore(Long guestIdHash) {
+        String v = redis.opsForValue().get(keyStore(guestIdHash));
+        return (v == null) ? null : Long.valueOf(v);
+    }
+
+    /**
+     * 장바구니 항목 저장 또는 수정
+     *
+     * @param guestIdHash 게스트 ID 해시값
+     * @param menuId      메뉴 ID
+     * @param quantity    수량
+     */
+    public void putItem(Long guestIdHash, Long menuId, int quantity) {
+        String itemsKey = keyItems(guestIdHash);
+        redis.opsForHash().put(itemsKey, String.valueOf(menuId), String.valueOf(quantity));
+        redis.expire(itemsKey, TTL);
+        redis.expire(keyStore(guestIdHash), TTL);
+    }
+
+    /**
+     * 장바구니 항목 삭제
+     *
+     * @param guestIdHash 게스트 ID 해시값
+     * @param menuId      메뉴 ID
+     */
+    public void removeItem(Long guestIdHash, Long menuId) {
+        String itemsKey = keyItems(guestIdHash);
+        redis.opsForHash().delete(itemsKey, String.valueOf(menuId));
+        redis.expire(itemsKey, TTL);
+        redis.expire(keyStore(guestIdHash), TTL);
+    }
+
+    /**
+     * 장바구니 항목 전체 조회
+     *
+     * @param guestIdHash 게스트 ID 해시값
+     * @return 메뉴 ID-수량 쌍의 맵
+     */
+    @SuppressWarnings("unchecked")
+    public Map<String, String> getAllItems(Long guestIdHash) {
+        return (Map<String, String>) (Map<?, ?>) redis.opsForHash().entries(keyItems(guestIdHash));
+    }
+
+    /**
+     * 장바구니 전체 삭제
+     *
+     * @param guestIdHash 게스트 ID 해시값
+     */
+    public void deleteCart(Long guestIdHash) {
+        redis.delete(keyStore(guestIdHash));
+        redis.delete(keyItems(guestIdHash));
+    }
+}

--- a/src/main/java/com/example/eat_together/domain/cart/repository/SharedCartItemRepository.java
+++ b/src/main/java/com/example/eat_together/domain/cart/repository/SharedCartItemRepository.java
@@ -5,9 +5,25 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
 
+/**
+ * 공유 장바구니 항목 관련 JPA 레포지토리
+ */
 public interface SharedCartItemRepository extends JpaRepository<SharedCartItem, Long> {
 
+    /**
+     * 채팅방 ID와 사용자 ID로 공유 장바구니 항목 목록 조회
+     *
+     * @param roomId 채팅방 ID
+     * @param userId 사용자 ID
+     * @return 공유 장바구니 항목 목록
+     */
     List<SharedCartItem> findBySharedCart_ChatRoom_IdAndUser_UserId(Long roomId, Long userId);
 
+    /**
+     * 채팅방 ID로 공유 장바구니 항목 목록 조회
+     *
+     * @param roomId 채팅방 ID
+     * @return 공유 장바구니 항목 목록
+     */
     List<SharedCartItem> findBySharedCart_ChatRoom_Id(Long roomId);
 }

--- a/src/main/java/com/example/eat_together/domain/cart/repository/SharedCartRepository.java
+++ b/src/main/java/com/example/eat_together/domain/cart/repository/SharedCartRepository.java
@@ -5,6 +5,16 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.Optional;
 
+/**
+ * 공유 장바구니 관련 JPA 레포지토리
+ */
 public interface SharedCartRepository extends JpaRepository<SharedCart, Long> {
+
+    /**
+     * 채팅방 ID로 공유 장바구니 조회
+     *
+     * @param chatRoomId 채팅방 ID
+     * @return 공유 장바구니 엔티티 Optional
+     */
     Optional<SharedCart> findByChatRoomId(Long chatRoomId);
 }

--- a/src/main/java/com/example/eat_together/domain/cart/service/CartService.java
+++ b/src/main/java/com/example/eat_together/domain/cart/service/CartService.java
@@ -5,12 +5,10 @@ import com.example.eat_together.domain.cart.dto.response.CartItemResponseDto;
 import com.example.eat_together.domain.cart.dto.response.CartResponseDto;
 import com.example.eat_together.domain.cart.entity.Cart;
 import com.example.eat_together.domain.cart.entity.CartItem;
-import com.example.eat_together.domain.cart.entity.SharedCartItem;
 import com.example.eat_together.domain.cart.repository.CartItemRepository;
 import com.example.eat_together.domain.cart.repository.CartRepository;
 import com.example.eat_together.domain.menu.entity.Menu;
 import com.example.eat_together.domain.menu.repository.MenuRepository;
-import com.example.eat_together.domain.store.entity.Store;
 import com.example.eat_together.domain.store.repository.StoreRepository;
 import com.example.eat_together.domain.users.common.entity.User;
 import com.example.eat_together.domain.users.user.repository.UserRepository;
@@ -24,7 +22,7 @@ import java.util.List;
 import java.util.stream.Collectors;
 
 /**
- * 장바구니 도메인의 비즈니스 로직을 담당하는 서비스 클래스
+ * 장바구니 도메인의 비즈니스 로직을 처리하는 서비스
  */
 @Service
 @RequiredArgsConstructor
@@ -51,7 +49,7 @@ public class CartService {
         Menu menu = menuRepository.findById(requestDto.getMenuId())
                 .orElseThrow(() -> new CustomException(ErrorCode.MENU_NOT_FOUND));
 
-        Store store = storeRepository.findById(storeId)
+        storeRepository.findById(storeId)
                 .orElseThrow(() -> new CustomException(ErrorCode.STORE_NOT_FOUND));
 
         Cart cart = cartRepository.findByUserUserId(userId)
@@ -117,13 +115,11 @@ public class CartService {
                 .build();
     }
 
-
-
     /**
      * 장바구니 항목 수량 수정
      *
      * @param itemId     항목 ID
-     * @param requestDto 수정할 수량 정보
+     * @param requestDto 변경할 수량 정보
      */
     @Transactional
     public void updateQuantity(Long itemId, CartItemRequestDto requestDto) {
@@ -136,7 +132,6 @@ public class CartService {
 
         cartItem.updateQuantity(requestDto.getQuantity());
     }
-
 
     /**
      * 장바구니 항목 삭제

--- a/src/main/java/com/example/eat_together/domain/cart/service/GuestCartService.java
+++ b/src/main/java/com/example/eat_together/domain/cart/service/GuestCartService.java
@@ -1,0 +1,221 @@
+package com.example.eat_together.domain.cart.service;
+
+import com.example.eat_together.domain.cart.dto.request.CartItemRequestDto;
+import com.example.eat_together.domain.cart.dto.response.CartResponseDto;
+import com.example.eat_together.domain.cart.entity.Cart;
+import com.example.eat_together.domain.cart.entity.CartItem;
+import com.example.eat_together.domain.cart.repository.CartRepository;
+import com.example.eat_together.domain.cart.repository.GuestCartRepository;
+import com.example.eat_together.domain.menu.entity.Menu;
+import com.example.eat_together.domain.menu.repository.MenuRepository;
+import com.example.eat_together.domain.store.entity.Store;
+import com.example.eat_together.domain.store.repository.StoreRepository;
+import com.example.eat_together.domain.users.common.entity.User;
+import com.example.eat_together.domain.users.user.repository.UserRepository;
+import com.example.eat_together.global.exception.CustomException;
+import com.example.eat_together.global.exception.ErrorCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Map;
+
+/**
+ * 비회원(게스트) 장바구니 도메인의 비즈니스 로직을 처리하는 서비스
+ */
+@Service
+@RequiredArgsConstructor
+public class GuestCartService {
+
+    private final GuestCartRepository guestCartRepository;
+    private final MenuRepository menuRepository;
+    private final StoreRepository storeRepository;
+    private final CartRepository cartRepository;
+    private final UserRepository userRepository;
+
+    /**
+     * 게스트 ID 문자열을 해시값으로 변환
+     *
+     * @param guestCartId 게스트 장바구니 ID(UUID)
+     * @return 해시값
+     */
+    private Long hash(String guestCartId) {
+        return Math.abs(guestCartId.hashCode() + 1469598103934665603L);
+    }
+
+    /**
+     * 게스트 장바구니에 항목 추가
+     *
+     * @param guestCartId 게스트 장바구니 ID
+     * @param storeId     매장 ID
+     * @param req         메뉴 및 수량 정보
+     */
+    @Transactional
+    public void addItem(String guestCartId, Long storeId, CartItemRequestDto req) {
+        Long key = hash(guestCartId);
+
+        Menu menu = menuRepository.findById(req.getMenuId())
+                .orElseThrow(() -> new CustomException(ErrorCode.MENU_NOT_FOUND));
+
+        storeRepository.findById(storeId)
+                .orElseThrow(() -> new CustomException(ErrorCode.STORE_NOT_FOUND));
+
+        if (!menu.getStore().getStoreId().equals(storeId)) {
+            throw new CustomException(ErrorCode.CART_INVALID_STORE);
+        }
+
+        Long existingStore = guestCartRepository.getStore(key);
+        if (existingStore == null) {
+            guestCartRepository.setStore(key, storeId);
+        } else if (!existingStore.equals(storeId)) {
+            throw new CustomException(ErrorCode.CART_INVALID_STORE);
+        }
+
+        Map<String, String> items = guestCartRepository.getAllItems(key);
+        String k = String.valueOf(req.getMenuId());
+        int cur = Integer.parseInt(items.getOrDefault(k, "0"));
+
+        int next = cur + req.getQuantity();
+        if (next < 1 || next > 99) {
+            throw new CustomException(ErrorCode.CART_EXCEEDS_MAX_QUANTITY);
+        }
+
+        guestCartRepository.putItem(key, req.getMenuId(), next);
+    }
+
+    /**
+     * 게스트 장바구니 조회
+     *
+     * @param guestCartId 게스트 장바구니 ID
+     * @return 장바구니 응답 DTO
+     */
+    @Transactional(readOnly = true)
+    public CartResponseDto getCart(String guestCartId) {
+        Long key = hash(guestCartId);
+        Long storeId = guestCartRepository.getStore(key);
+        Map<String, String> items = guestCartRepository.getAllItems(key);
+
+        if (storeId == null || items.isEmpty()) {
+            throw new CustomException(ErrorCode.CART_ITEM_NOT_FOUND);
+        }
+
+        Store store = storeRepository.findById(storeId)
+                .orElseThrow(() -> new CustomException(ErrorCode.STORE_NOT_FOUND));
+        double deliveryFee = store.getDeliveryFee();
+
+        var content = items.entrySet().stream()
+                .map(e -> {
+                    Long menuId = Long.valueOf(e.getKey());
+                    int qty = Integer.parseInt(e.getValue());
+                    Menu menu = menuRepository.findById(menuId)
+                            .orElseThrow(() -> new CustomException(ErrorCode.MENU_NOT_FOUND));
+                    double price = menu.getPrice();
+                    return com.example.eat_together.domain.cart.dto.response.CartItemResponseDto.builder()
+                            .itemId(menuId) // 게스트는 itemId 대신 menuId 사용
+                            .menuName(menu.getName())
+                            .quantity(qty)
+                            .price(price)
+                            .totalPrice(price * qty)
+                            .build();
+                })
+                .toList();
+
+        double sub = content.stream()
+                .mapToDouble(com.example.eat_together.domain.cart.dto.response.CartItemResponseDto::getTotalPrice)
+                .sum();
+
+        return com.example.eat_together.domain.cart.dto.response.CartResponseDto.builder()
+                .storeId(storeId)
+                .content(content)
+                .subPrice(sub)
+                .deliveryFee(deliveryFee)
+                .storeTotalPrice(sub + deliveryFee)
+                .build();
+    }
+
+    /**
+     * 게스트 장바구니 항목 수량 변경
+     *
+     * @param guestCartId 게스트 장바구니 ID
+     * @param menuId      메뉴 ID
+     * @param quantity    변경할 수량
+     */
+    @Transactional
+    public void updateItem(String guestCartId, Long menuId, int quantity) {
+        Long key = hash(guestCartId);
+        if (quantity < 1 || quantity > 99) {
+            throw new CustomException(ErrorCode.CART_EXCEEDS_MAX_QUANTITY);
+        }
+        guestCartRepository.putItem(key, menuId, quantity);
+    }
+
+    /**
+     * 게스트 장바구니 항목 삭제
+     *
+     * @param guestCartId 게스트 장바구니 ID
+     * @param menuId      메뉴 ID
+     */
+    @Transactional
+    public void deleteItem(String guestCartId, Long menuId) {
+        Long key = hash(guestCartId);
+        guestCartRepository.removeItem(key, menuId);
+    }
+
+    /**
+     * 게스트 장바구니를 회원 장바구니로 병합
+     *
+     * @param guestCartId 게스트 장바구니 ID
+     * @param userId      사용자 ID
+     */
+    @Transactional
+    public void mergeToUserCart(String guestCartId, Long userId) {
+        Long key = hash(guestCartId);
+        Map<String, String> items = guestCartRepository.getAllItems(key);
+        if (items == null || items.isEmpty()) return;
+
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
+        Cart cart = cartRepository.findByUserUserId(userId)
+                .orElseGet(() -> cartRepository.save(Cart.of(user)));
+
+        Long guestStoreId = guestCartRepository.getStore(key);
+
+        if (!cart.getCartItems().isEmpty()) {
+            Long existingStoreId = cart.getCartItems().get(0).getMenu().getStore().getStoreId();
+            if (guestStoreId != null && !existingStoreId.equals(guestStoreId)) {
+                throw new CustomException(ErrorCode.CART_INVALID_STORE);
+            }
+        }
+
+        if (guestStoreId != null) {
+            Store store = storeRepository.findById(guestStoreId)
+                    .orElseThrow(() -> new CustomException(ErrorCode.STORE_NOT_FOUND));
+            if (cart.getCartItems().isEmpty() || cart.getDeliveryFee() == 0.0) {
+                cart.setDeliveryFee(store.getDeliveryFee());
+            }
+        }
+
+        for (var e : items.entrySet()) {
+            Long menuId = Long.valueOf(e.getKey());
+            int addQty = Integer.parseInt(e.getValue());
+
+            Menu menu = menuRepository.findById(menuId)
+                    .orElseThrow(() -> new CustomException(ErrorCode.MENU_NOT_FOUND));
+
+            var existing = cart.getCartItems().stream()
+                    .filter(ci -> ci.getMenu().getMenuId().equals(menuId))
+                    .findFirst();
+
+            if (existing.isPresent()) {
+                int next = existing.get().getQuantity() + addQty;
+                if (next > 99) next = 99;
+                existing.get().updateQuantity(next);
+            } else {
+                CartItem newItem = CartItem.of(menu, Math.min(addQty, 99));
+                cart.addCartItem(newItem);
+            }
+        }
+
+        guestCartRepository.deleteCart(key);
+    }
+}

--- a/src/main/java/com/example/eat_together/domain/chat/repository/ChatRoomUserRepository.java
+++ b/src/main/java/com/example/eat_together/domain/chat/repository/ChatRoomUserRepository.java
@@ -16,4 +16,5 @@ public interface ChatRoomUserRepository extends JpaRepository<ChatRoomUser, Long
                 WHERE cru.user.userId = :userid AND cru.chatRoom.id = :roomid
             """)
     void deleteByUserIdAndRoomId(@Param("userid") Long userId, @Param("roomid") Long roomId);
+    boolean existsByUserUserIdAndChatRoomId(Long userId, Long roomId);
 }

--- a/src/main/java/com/example/eat_together/global/config/SecurityConfig.java
+++ b/src/main/java/com/example/eat_together/global/config/SecurityConfig.java
@@ -45,6 +45,11 @@ public class SecurityConfig {
                                 "/actuator/prometheus",
                                 "/chats/**")
                         .permitAll()
+
+                        // 게스트 카트: merge는 인증 필요, 나머지 게스트 카트는 무인증
+                        .requestMatchers("/guest-carts/merge").authenticated()
+                        .requestMatchers("/stores/**/guest-carts/**", "/guest-carts/**").permitAll()
+
                         // 그 외의 요청은 @PreAuthorize를 사용하여 확인
                         .anyRequest().authenticated()
                 )

--- a/src/test/java/com/example/eat_together/domain/cart/controller/CartControllerTest.java
+++ b/src/test/java/com/example/eat_together/domain/cart/controller/CartControllerTest.java
@@ -1,6 +1,7 @@
 package com.example.eat_together.domain.cart.controller;
 
 import com.example.eat_together.domain.cart.dto.request.CartItemRequestDto;
+import com.example.eat_together.domain.cart.dto.response.CartItemResponseDto;
 import com.example.eat_together.domain.cart.dto.response.CartResponseDto;
 import com.example.eat_together.domain.cart.service.CartService;
 import com.example.eat_together.global.exception.CustomException;
@@ -17,6 +18,8 @@ import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 
+import java.lang.reflect.Constructor;
+import java.util.Collections;
 import java.util.List;
 
 import static org.mockito.ArgumentMatchers.any;
@@ -116,10 +119,12 @@ class CartControllerTest {
         @WithMockUser(username = "1")
         void getCart_success() throws Exception {
             // given
-            CartResponseDto dummyResponse = new CartResponseDto(
+            CartResponseDto dummyResponse = newCartResponse(
                     10L,
-                    List.of(),
-                    3000.0
+                    Collections.<CartItemResponseDto>emptyList(), // 타입 안전한 빈 리스트
+                    0.0,     // subtotal
+                    3000.0,  // deliveryFee
+                    3000.0   // total
             );
 
             given(cartService.getCart(1L)).willReturn(dummyResponse);
@@ -129,6 +134,19 @@ class CartControllerTest {
                             .contentType(MediaType.APPLICATION_JSON))
                     .andExpect(status().isOk())
                     .andExpect(jsonPath("$.message").value("장바구니를 조회했습니다."));
+        }
+
+        private CartResponseDto newCartResponse(
+                Long cartId,
+                java.util.List<CartItemResponseDto> items,
+                double subtotal,
+                double deliveryFee,
+                double total
+        ) throws Exception {
+            Constructor<CartResponseDto> ctor =
+                    CartResponseDto.class.getDeclaredConstructor(Long.class, java.util.List.class, double.class, double.class, double.class);
+            ctor.setAccessible(true);
+            return ctor.newInstance(cartId, items, subtotal, deliveryFee, total);
         }
     }
 


### PR DESCRIPTION
## 이슈 번호
#181 

## 작업 내용
- 비회원 장바구니 CRUD 기능 구현
           - Redis 기반으로 비회원 장바구니 저장 및 TTL(14일) 적용
           - 메뉴 추가, 조회, 수정, 삭제 API 구현

- 회원가입/로그인 시 장바구니 병합 기능 구현
           - 비회원 장바구니 데이터를 회원 장바구니로 이관
           - 동일 메뉴일 경우 수량 합산 처리

- 공유 장바구니 접근 제어(Guard) 추가
           - 채팅방 비회원이 공유 장바구니 접근 시 차단
           - 메뉴 추가, 조회, 수정, 삭제 API 모두 검증 로직 적용

- javadoc 스타일 주석 추가