### PR TITLE
chore: Gradle wrapper 네트워크 타임아웃을 60초로 변경

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,7 +1,7 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.3-bin.zip
-networkTimeout=10000
+networkTimeout=60000  
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
## 이슈 번호
#198 
## 작업 내용
-Gradle wrapper 네트워크 타임아웃을 60초로 변경
## 스크린샷(선택)
